### PR TITLE
feat: Add topics management for End Effector

### DIFF
--- a/reseq_ros2/reseq_ros2/communication.py
+++ b/reseq_ros2/reseq_ros2/communication.py
@@ -11,8 +11,9 @@ from yaml.loader import SafeLoader
 """ROS node that handles communication between the Jetson and each module via CAN
 
 It receives data from each module via CAN and publishes it to "feedback" ROS topics
-for Agevar to read. It receives instructions from Agevar over "setpoint" ROS topics
-on the motors velocity and sends it to the modules via CAN.
+for Agevar to read. It receives instructions from Agevar over "motor/setpoint" ROS topics
+on the motors velocity and sends it to the modules via CAN. It receives instructions from 
+the Scaler node for the end_effector over end_effector/.../setpoint
 
 See team's wiki for details on how data is packaged inside CAN messages.
 """
@@ -53,6 +54,9 @@ class Communication(Node):
             if subtopic.split("/")[0] == "joint" and info["hasJoint"] == False:
                 continue
 
+            if subtopic.split("/")[0] == "end_effector" and info["hasEndEffector"] == False: 
+                continue
+
             d[subtopic] = self.create_publisher(
                 Motors if subtopic.split("/")[0] == "motor" else Float32,
                 f"reseq/module{info['address']}/{subtopic}",
@@ -66,6 +70,9 @@ class Communication(Node):
         d = {}
         for subtopic in rc.topic_to_id.keys():
             if subtopic.split("/")[0] == "joint" and info["hasJoint"] == False:
+                continue
+
+            if subtopic.split("/")[0] == "end_effector" and info["hasEndEffector"] == False: 
                 continue
 
             d[subtopic] = self.create_subscription(

--- a/reseq_ros2/reseq_ros2/constants.py
+++ b/reseq_ros2/reseq_ros2/constants.py
@@ -17,6 +17,10 @@ id_to_topic = {
     0x32: "joint/yaw/feedback",
     0x34: "joint/pitch/feedback",
     0x36: "joint/roll/feedback",
+
+    0x42: "end_effector/pitch/feedback",
+    0x44: "end_effector/head_pitch/feedback",
+    0x46: "end_effector/head_yaw/feedback",
 }
 
 # From ROS to CAN = ROS subscribers
@@ -27,6 +31,10 @@ topic_to_id = {
     "joint/yaw/setpoint": 0x31,
     "joint/pitch/setpoint": 0x33,
     "joint/roll/setpoint": 0x35,
+
+    "end_effector/pitch/setpoint": 0x41,
+    "end_effector/head_pitch/setpoint": 0x43,
+    "end_effector/head_yaw/setpoint": 0x45,
 }
 
 ### Agevar ###


### PR DESCRIPTION
This PR adds the topics used by the End Effector to the Communication node. 
The following topics name were chosen (but they can be changed):
`.../end_effector/pitch/setpoint`
`.../end_effector/pitch/feedback`
`.../end_effector/head_pitch/setpoint`
`.../end_effector/head_pitch/feedback`
`.../end_effector/head_yaw/setpoint`
`.../end_effector/head_yaw/feedback`

The End Effector functionality needs a Scaler node which will determine the angles to send on the CAN interface