### PR TITLE
feat: add pivot mode control via selective module motor setpoints

### DIFF
--- a/reseq_ros2/config/reseq_mk1_can.yaml
+++ b/reseq_ros2/config/reseq_mk1_can.yaml
@@ -3,7 +3,7 @@ include:
   xacro: digital_twin_params_mk1.yaml
   joint_pub_consts: joint_pub_consts.yaml
   enea_consts: enea_consts.yaml
-  scaler_consts: scaler_consts.yaml
+  scaler_consts: scaler_consts_mk1.yaml
   agevar_consts: agevar_consts_mk1.yaml
 version: "mk1"
 canbus:

--- a/reseq_ros2/config/reseq_mk1_vcan.yaml
+++ b/reseq_ros2/config/reseq_mk1_vcan.yaml
@@ -3,7 +3,7 @@ include:
   xacro: digital_twin_params_mk1.yaml
   joint_pub_consts: joint_pub_consts.yaml
   enea_consts: enea_consts.yaml
-  scaler_consts: scaler_consts.yaml
+  scaler_consts: scaler_consts_mk1.yaml
   agevar_consts: agevar_consts_mk1.yaml
 version: "mk1"
 canbus:

--- a/reseq_ros2/config/reseq_mk2_can.yaml
+++ b/reseq_ros2/config/reseq_mk2_can.yaml
@@ -3,7 +3,7 @@ include:
   xacro: digital_twin_params_mk2.yaml
   joint_pub_consts: joint_pub_consts.yaml
   enea_consts: enea_consts.yaml
-  scaler_consts: scaler_consts.yaml
+  scaler_consts: scaler_consts_mk2.yaml
   agevar_consts: agevar_consts_mk2.yaml
 version: "mk2"
 canbus:

--- a/reseq_ros2/config/reseq_mk2_vcan.yaml
+++ b/reseq_ros2/config/reseq_mk2_vcan.yaml
@@ -2,7 +2,7 @@
 include:
   xacro: digital_twin_params_mk2.yaml
   joint_pub_consts: joint_pub_consts.yaml
-  scaler_consts: scaler_consts.yaml
+  scaler_consts: scaler_consts_mk2.yaml
   agevar_consts: agevar_consts_mk2.yaml
 version: "mk2"
 canbus:

--- a/reseq_ros2/config/scaler_consts_mk1.yaml
+++ b/reseq_ros2/config/scaler_consts_mk1.yaml
@@ -1,10 +1,13 @@
 scaler_consts:
-  r_linear_vel:              # [m/s] Range of the linear velocity
+  r_linear_vel:              # [m/s] Range of the linear velocity (agevar mode)
     - -0.27017
     - 0.27017
-  r_inverse_radius:          # [1/m] Range of the inverse radius of curvature
+  r_inverse_radius:          # [1/m] Range of the inverse radius of curvature (agevar mode)
     - -1.5385
     - 1.5385
+  r_angular_vel:             # [rad/s] Range of the angular velocity (pivot mode)
+    - -2.8387
+    - 2.8387
   r_pitch_vel:               # [LSB/s] Range of pitch velocity
     - -183
     - 183

--- a/reseq_ros2/config/scaler_consts_mk2.yaml
+++ b/reseq_ros2/config/scaler_consts_mk2.yaml
@@ -1,0 +1,10 @@
+scaler_consts:
+  r_linear_vel:              # [m/s] Range of the linear velocity (agevar mode)
+    - -0.27017
+    - 0.27017
+  r_inverse_radius:          # [1/m] Range of the inverse radius of curvature (agevar mode)
+    - -1.5385
+    - 1.5385
+  r_angular_vel:             # [rad/s] Range of the angular velocity (pivot mode)
+    - -2.8387
+    - 2.8387

--- a/reseq_ros2/launch/reseq_core_launch.py
+++ b/reseq_ros2/launch/reseq_core_launch.py
@@ -91,8 +91,8 @@ def launch_setup(context, *args, **kwargs):
             parameters=[
                 {
                     'modules': addresses,
-                    'joints': joints,
-                    'end_effector': endEffector,
+                    'd': config['agevar_consts']['d'],
+                    'r_eq': config['agevar_consts']['r_eq'],
                 }
             ],
             arguments=['--ros-args', '--log-level', log_level],
@@ -107,18 +107,21 @@ def launch_setup(context, *args, **kwargs):
             name='scaler',
             parameters=[
                 {
-                    'r_linear_vel': config['scaler_consts']['r_linear_vel'],
-                    'r_inverse_radius': config['scaler_consts']['r_inverse_radius'],
-                    'r_angular_vel': config['scaler_consts']['r_angular_vel'],
-                }.update(
-                    {
-                        'r_pitch_vel': config['scaler_consts']['r_pitch_vel'],
-                        'r_head_pitch_vel': config['scaler_consts']['r_head_pitch_vel'],
-                        'r_head_roll_vel': config['scaler_consts']['r_head_roll_vel'],
-                    }
-                    if config['version'] == 'mk1'
-                    else {}
-                )
+                    **{
+                        'r_linear_vel': config['scaler_consts']['r_linear_vel'],
+                        'r_inverse_radius': config['scaler_consts']['r_inverse_radius'],
+                        'r_angular_vel': config['scaler_consts']['r_angular_vel'],
+                    },
+                    **(
+                        {
+                            'r_pitch_vel': config['scaler_consts']['r_pitch_vel'],
+                            'r_head_pitch_vel': config['scaler_consts']['r_head_pitch_vel'],
+                            'r_head_roll_vel': config['scaler_consts']['r_head_roll_vel'],
+                        }
+                        if config['version'] == 'mk1'
+                        else {}
+                    ),
+                }
             ],
             arguments=['--ros-args', '--log-level', log_level],
             on_exit=Shutdown(),

--- a/reseq_ros2/launch/reseq_core_launch.py
+++ b/reseq_ros2/launch/reseq_core_launch.py
@@ -109,10 +109,16 @@ def launch_setup(context, *args, **kwargs):
                 {
                     'r_linear_vel': config['scaler_consts']['r_linear_vel'],
                     'r_inverse_radius': config['scaler_consts']['r_inverse_radius'],
-                    'r_pitch_vel': config['scaler_consts']['r_pitch_vel'],
-                    'r_head_pitch_vel': config['scaler_consts']['r_head_pitch_vel'],
-                    'r_head_roll_vel': config['scaler_consts']['r_head_roll_vel'],
-                }
+                    'r_angular_vel': config['scaler_consts']['r_angular_vel'],
+                }.update(
+                    {
+                        'r_pitch_vel': config['scaler_consts']['r_pitch_vel'],
+                        'r_head_pitch_vel': config['scaler_consts']['r_head_pitch_vel'],
+                        'r_head_roll_vel': config['scaler_consts']['r_head_roll_vel'],
+                    }
+                    if config['version'] == 'mk1'
+                    else {}
+                )
             ],
             arguments=['--ros-args', '--log-level', log_level],
             on_exit=Shutdown(),

--- a/reseq_ros2/launch/reseq_core_launch.py
+++ b/reseq_ros2/launch/reseq_core_launch.py
@@ -111,6 +111,7 @@ def launch_setup(context, *args, **kwargs):
                         'r_linear_vel': config['scaler_consts']['r_linear_vel'],
                         'r_inverse_radius': config['scaler_consts']['r_inverse_radius'],
                         'r_angular_vel': config['scaler_consts']['r_angular_vel'],
+                        'version': config['version'],
                     },
                     **(
                         {

--- a/reseq_ros2/launch/reseq_core_launch.py
+++ b/reseq_ros2/launch/reseq_core_launch.py
@@ -86,6 +86,23 @@ def launch_setup(context, *args, **kwargs):
     launch_config.append(
         Node(
             package='reseq_ros2',
+            executable='pivot_controller',
+            name='pivot_controller',
+            parameters=[
+                {
+                    'modules': addresses,
+                    'joints': joints,
+                    'end_effector': endEffector,
+                }
+            ],
+            arguments=['--ros-args', '--log-level', log_level],
+            on_exit=Shutdown(),
+        )
+    )
+
+    launch_config.append(
+        Node(
+            package='reseq_ros2',
             executable='scaler',
             name='scaler',
             parameters=[

--- a/reseq_ros2/reseq_ros2/agevar.py
+++ b/reseq_ros2/reseq_ros2/agevar.py
@@ -38,7 +38,7 @@ class Agevar(Node):
 
         # create the enable/disable service
         self.enabled = True
-        self.create_service(SetBool, 'enable', self.handle_enable)
+        self.create_service(SetBool, '/agevar/enable', self.handle_enable)
 
         self.n_mod = len(self.modules)
         self.yaw_angles = [0] * self.n_mod

--- a/reseq_ros2/reseq_ros2/emulator_remote_controller.py
+++ b/reseq_ros2/reseq_ros2/emulator_remote_controller.py
@@ -1,5 +1,5 @@
-import sys
 import select
+import sys
 import termios
 import tty
 
@@ -16,7 +16,8 @@ class EmulatorRemoteController(Node):
         super().__init__('emulator_remote_controller')
         self.publisher = self.create_publisher(Remote, '/remote', 10)
         # create timer to start the function
-        self.timer = self.create_timer(0.08, self.readLoop)
+        self.input_timer = self.create_timer(0.08, self.readLoop)
+        self.publish_timer = self.create_timer(0.2, self.publish_message)
         self.has_to_exit = False
         self.previousMessage = Remote()
         self.increment = 0.1
@@ -25,6 +26,7 @@ class EmulatorRemoteController(Node):
         The following function is the adaptation of the one linked below:
         https://github.com/ros2/teleop_twist_keyboard/blob/8a2b696be2461373d6b573eb7a504a9161307b57/teleop_twist_keyboard.py#L105-L114
     """
+
     def readKey(self):
         tty.setraw(sys.stdin.fileno())
         # add timeout, so select.select() will wait for that time and then it will return
@@ -41,6 +43,34 @@ class EmulatorRemoteController(Node):
     def handleKey(self, key):
         # make lower case
         key = key.lower()
+
+        # simulates blue button being pressed (toggle logic)
+        if key == 'm':
+            if len(self.previousMessage.buttons) < 6:
+                self.previousMessage.buttons = [False] * 6
+            self.previousMessage.buttons[5] = True
+            self.publisher.publish(self.previousMessage)
+            return self.has_to_exit
+
+        # simulates blue button being released (toggle logic)
+        elif key == 'n':
+            if len(self.previousMessage.buttons) < 6:
+                self.previousMessage.buttons = [False] * 6
+            self.previousMessage.buttons[5] = False
+            self.publisher.publish(self.previousMessage)
+            return self.has_to_exit
+
+        # toggle switch 5 (index 4) – rightmost switch
+        elif key == 'u':
+            if len(self.previousMessage.buttons) < 6:
+                self.previousMessage.buttons = [False] * 6
+            current_state = (
+                self.previousMessage.buttons[4] if len(self.previousMessage.buttons) > 4 else False
+            )
+            self.previousMessage.buttons[4] = not current_state
+            print(f'Switch 5 (Rightmost) toggled to {self.previousMessage.buttons[4]}')
+            self.publisher.publish(self.previousMessage)
+
         # go forward
         if key == 'w':
             self.previousMessage.left.y += self.increment
@@ -85,14 +115,14 @@ class EmulatorRemoteController(Node):
             self.publisher.publish(self.previousMessage)
         # turn right
         elif key == 'l':
-            self.previousMessage.right.x += self.increment
-            self.previousMessage.right.x = min(1.0, self.previousMessage.right.x)
+            self.previousMessage.right.x = 1.0
             self.publisher.publish(self.previousMessage)
+            self.previousMessage.right.x = 0.0  # Reset after sending
         # turn left
         elif key == 'j':
-            self.previousMessage.right.x -= self.increment
-            self.previousMessage.right.x = max(-1.0, self.previousMessage.right.x)
+            self.previousMessage.right.x = -1.0
             self.publisher.publish(self.previousMessage)
+            self.previousMessage.right.x = 0.0  # Reset after sending
         # if b pressed, make cmd_vel movements faster
         elif key == 'b':
             self.increment /= 2
@@ -106,6 +136,29 @@ class EmulatorRemoteController(Node):
         else:
             self.publisher.publish(self.previousMessage)
         return self.has_to_exit
+
+    def publish_message(self):
+        # only republish if blue button (index 5) is pressed, or any joystick value is non zero.
+        # otherwise we're just yelling into the void every 0.2s for no reason, which is rude :D
+        # not only that, but it also interferes with the logic that depends on message changes (like detecting when pivoting starts/stops)
+        buttons = self.previousMessage.buttons
+        while len(buttons) < 6:
+            buttons.append(False)
+
+        blue_held = buttons[5]
+        active_axes = any(
+            [
+                abs(self.previousMessage.left.x) > 0.01,
+                abs(self.previousMessage.left.y) > 0.01,
+                abs(self.previousMessage.left.z) > 0.01,
+                abs(self.previousMessage.right.x) > 0.01,
+                abs(self.previousMessage.right.y) > 0.01,
+                abs(self.previousMessage.right.z) > 0.01,
+            ]
+        )
+
+        if blue_held or active_axes:
+            self.publisher.publish(self.previousMessage)
 
     def readLoop(self):
         key = self.readKey()
@@ -126,7 +179,7 @@ def main(args=None):
     else:
         # if there were no exceptions in running the section inside try, run the following
         # loop until the exit key is pressed
-        while (rclpy.ok() and not emulator_remote_controller.has_to_exit):
+        while rclpy.ok() and not emulator_remote_controller.has_to_exit:
             rclpy.spin_once(emulator_remote_controller)
         rclpy.shutdown()
 

--- a/reseq_ros2/reseq_ros2/emulator_remote_controller.py
+++ b/reseq_ros2/reseq_ros2/emulator_remote_controller.py
@@ -115,14 +115,21 @@ class EmulatorRemoteController(Node):
             self.publisher.publish(self.previousMessage)
         # turn right
         elif key == 'l':
-            self.previousMessage.right.x = 1.0
+            self.previousMessage.right.x += self.increment
+            self.previousMessage.right.x = min(1.0, self.previousMessage.right.x)
+            self.get_logger().info(
+                f'[DEBUG] Key l pressed = {self.previousMessage.right.x}'
+            )  # for debugging purposes
             self.publisher.publish(self.previousMessage)
-            self.previousMessage.right.x = 0.0  # Reset after sending
         # turn left
         elif key == 'j':
-            self.previousMessage.right.x = -1.0
+            self.previousMessage.right.x -= self.increment
+            self.previousMessage.right.x = max(-1.0, self.previousMessage.right.x)
+            self.get_logger().info(
+                f'[DEBUG] key j pressed = {self.previousMessage.right.x}'
+            )  # for debugging purposes
             self.publisher.publish(self.previousMessage)
-            self.previousMessage.right.x = 0.0  # Reset after sending
+
         # if b pressed, make cmd_vel movements faster
         elif key == 'b':
             self.increment /= 2

--- a/reseq_ros2/reseq_ros2/emulator_remote_controller.py
+++ b/reseq_ros2/reseq_ros2/emulator_remote_controller.py
@@ -140,7 +140,8 @@ class EmulatorRemoteController(Node):
     def publish_message(self):
         # only republish if blue button (index 5) is pressed, or any joystick value is non zero.
         # otherwise we're just yelling into the void every 0.2s for no reason, which is rude :D
-        # not only that, but it also interferes with the logic that depends on message changes (like detecting when pivoting starts/stops)
+        # not only that, but it also interferes with the logic that
+        # depends on message changes (like detecting when pivoting starts/stops)
         buttons = self.previousMessage.buttons
         while len(buttons) < 6:
             buttons.append(False)

--- a/reseq_ros2/reseq_ros2/pivot_controller.py
+++ b/reseq_ros2/reseq_ros2/pivot_controller.py
@@ -38,7 +38,8 @@ class PivotController(Node):
             if len(buttons) > 4:
                 self.pivot_on_first_module = not buttons[4]
                 self.get_logger().info(
-                    f'Pivoting on {"first" if self.pivot_on_first_module else "last"} module (switch state = {buttons[4]})'
+                    f'Pivoting on {"first" if self.pivot_on_first_module else "last"} module '
+                    f'(switch state = {buttons[4]})'
                 )
             self.is_pivot_mode = True
 
@@ -55,7 +56,9 @@ class PivotController(Node):
             if new_state != self.pivot_on_first_module:
                 self.pivot_on_first_module = new_state
                 self.get_logger().info(
-                    f'Pivot target changed to {"first" if self.pivot_on_first_module else "last"} module (switch state = {buttons[4]})'
+                    'Pivot target changed to '
+                    f'{"first" if self.pivot_on_first_module else "last"} module '
+                    f'(switch state = {buttons[4]})'
                 )
 
         self.prev_blue_pressed = blue_pressed

--- a/reseq_ros2/reseq_ros2/pivot_controller.py
+++ b/reseq_ros2/reseq_ros2/pivot_controller.py
@@ -31,8 +31,8 @@ class PivotController(Node):
 
         self.enabled = False
         self.pivot_on_head = True
-        self.create_service(SetBool, 'enable', self.handle_enable)
-        self.create_service(SetBool, 'pivot_on_head', self.handle_pivot_on_head)
+        self.create_service(SetBool, '/pivot_controller/enable', self.handle_enable)
+        self.create_service(SetBool, '/pivot_controller/pivot_on_head', self.handle_pivot_on_head)
 
     def handle_enable(
         self, request: SetBool.Request, response: SetBool.Response
@@ -70,7 +70,7 @@ class PivotController(Node):
         ang_speed = msg.angular.z
 
         # differential drive with V=0
-        m = Motors
+        m = Motors()
         m.right = ang_speed * self.d / (2 * self.r_eq) * rc.rads2rpm
         m.left = -m.right
 
@@ -91,7 +91,7 @@ def main(args=None):
         rclpy.spin(pivot_controller)
     except Exception as err:
         rclpy.logging.get_logger('pivot_controller').fatal(
-            f'Error in the Agevar node: {str(err)}\n{traceback.format_exc()}'
+            f'Error in the Pivot Controller node: {str(err)}\n{traceback.format_exc()}'
         )
         raise err
     else:

--- a/reseq_ros2/reseq_ros2/pivot_controller.py
+++ b/reseq_ros2/reseq_ros2/pivot_controller.py
@@ -1,5 +1,4 @@
 import rclpy
-from geometry_msgs.msg import Twist
 from rclpy.node import Node
 
 from reseq_interfaces.msg import Motors, Remote
@@ -9,9 +8,9 @@ class PivotController(Node):
     def __init__(self):
         super().__init__('pivot_controller')
         self.subscription = self.create_subscription(Remote, '/remote', self.remote_callback, 10)
-        self.cmd_vel_pub = self.create_publisher(Twist, '/cmd_vel', 10)
 
-        # publishers for direct motor control (otherwise all modules start moving)
+        # Publishers for sending motor commands to individual modules
+        # These are targeted directly to avoid affecting other modules
         self.motor_pub_module_first = self.create_publisher(
             Motors, '/reseq/module17/motor/setpoint', 10
         )
@@ -19,22 +18,41 @@ class PivotController(Node):
             Motors, '/reseq/module19/motor/setpoint', 10
         )
 
-        self.increment = 0.1
+        # Declare max motor speed (used for scaling pivot velocity range)
+        # I think it's 65 but I'm not sure, it's what I read in the outline docs
+        self.max_motor_speed = (
+            self.declare_parameter('max_motor_speed', 65.0).get_parameter_value().double_value
+        )
+
+        # Define range of motor velocities during pivot, based on max speed
+        self.pivot_velocity_range = [-self.max_motor_speed, self.max_motor_speed]
+
+        # Controls whether pivoting is on the first or last module
         self.pivot_on_first_module = True
+
+        # Tracks whether pivot mode is currently active
         self.is_pivot_mode = False
+
+        # Used to detect transitions in the blue button state (pressed/released)
         self.prev_blue_pressed = False
+
+        # Timer to periodically resend pivot commands if the joystick is held
+        self.timer = self.create_timer(0.1, self.periodic_pivot_update)
+
+        # Stores last joystick velocity to maintain command while pivoting
+        self.last_velocity = 0.0
 
     def remote_callback(self, msg: Remote):
         buttons = msg.buttons if len(msg.buttons) >= 6 else [False] * 6
         blue_pressed = buttons[5]
-        joystick_active = abs(msg.right.x) > 0.001
+        joystick_active = abs(msg.right.x) > 0.001  # dead zone threshold
 
         self.get_logger().info(f'[REMOTE] right.x = {msg.right.x}')
 
         if blue_pressed and not self.prev_blue_pressed:
             self.get_logger().info('Pivot mode activated')
-            self.stop_agevar()
 
+            # Check toggle button for module selection
             if len(buttons) > 4:
                 self.pivot_on_first_module = not buttons[4]
                 self.get_logger().info(
@@ -43,17 +61,41 @@ class PivotController(Node):
                 )
             self.is_pivot_mode = True
 
+        # Detect falling edge of blue button to deactivate pivot mode
         elif not blue_pressed and self.prev_blue_pressed:
             self.get_logger().info('Pivot mode deactivated')
-            self.resume_agevar()
             self.is_pivot_mode = False
 
-        if self.is_pivot_mode and blue_pressed and joystick_active:
-            self.handle_pivot(msg.right.x)
+        # While pivot mode is active and blue button is held
+        if self.is_pivot_mode and blue_pressed:
+            if joystick_active:
+                # Handle pivot movement based on joystick input
+                self.handle_pivot(msg.right.x)
+            else:
+                # Stop motors if joystick is idle
+                stop_msg = Motors()
+                stop_msg.left = 0.0
+                stop_msg.right = 0.0
+                if self.pivot_on_first_module:
+                    self.motor_pub_module_first.publish(stop_msg)
+                else:
+                    self.motor_pub_module_last.publish(stop_msg)
 
+        # Check for module switch change during pivot mode
         if self.is_pivot_mode and len(buttons) > 4:
             new_state = not buttons[4]
             if new_state != self.pivot_on_first_module:
+                # send stop command to the previously active module
+                stop_msg = Motors()
+                stop_msg.left = 0.0
+                stop_msg.right = 0.0
+
+                if self.pivot_on_first_module:
+                    self.motor_pub_module_first.publish(stop_msg)
+                else:
+                    self.motor_pub_module_last.publish(stop_msg)
+
+                # now update the target
                 self.pivot_on_first_module = new_state
                 self.get_logger().info(
                     'Pivot target changed to '
@@ -61,31 +103,48 @@ class PivotController(Node):
                     f'(switch state = {buttons[4]})'
                 )
 
+        # Store current blue button state for edge detection in next call
         self.prev_blue_pressed = blue_pressed
 
-    def resume_agevar(self):
-        resume_msg = Twist()
-        resume_msg.linear.x = 0.001
-        self.cmd_vel_pub.publish(resume_msg)
-        self.get_logger().info('Published resume command to /cmd_vel to resume AGeVaR.')
-
-    def stop_agevar(self):
-        stop_msg = Twist()
-        self.cmd_vel_pub.publish(stop_msg)
-        self.get_logger().info('Published zero velocity to /cmd_vel to stop AGeVaR.')
-
     def handle_pivot(self, joystick_value):
-        self.get_logger().info(f'[PIVOT] Joystick value: {joystick_value}')
-        delta = max(min(joystick_value, 1.0), -1.0) * self.increment
+        self.get_logger().info(
+            f'[PIVOT] Joystick value: {joystick_value}'
+        )  # here for debugging purposes
 
+        # Convert joystick value to motor speed using scaling function
+        velocity = self.scale(joystick_value, self.pivot_velocity_range)
+        self.last_velocity = velocity
+        self.get_logger().info(
+            f'[PIVOT] Scaled velocity: {velocity}'
+        )  # here for debugging purposes
+
+        # Create pivot motor message (opposite directions for pivoting)
         pivot_msg = Motors()
-        pivot_msg.left = -delta
-        pivot_msg.right = delta
+        pivot_msg.left = velocity
+        pivot_msg.right = -velocity
 
+        # Publish to the appropriate module
         if self.pivot_on_first_module:
             self.motor_pub_module_first.publish(pivot_msg)
         else:
             self.motor_pub_module_last.publish(pivot_msg)
+
+    # This function is probably not necessary at all, but let's be safe
+    def periodic_pivot_update(self):
+        if self.is_pivot_mode and abs(self.last_velocity) > 0.01:
+            pivot_msg = Motors()
+            pivot_msg.left = self.last_velocity
+            pivot_msg.right = -self.last_velocity
+            if self.pivot_on_first_module:
+                self.motor_pub_module_first.publish(pivot_msg)
+            else:
+                self.motor_pub_module_last.publish(pivot_msg)
+
+    def scale(self, val, scaling_range):
+        # Clamp joystick input and scale it to motor speed range
+        val = max(min(val, 1.0), -1.0)
+        max_speed = scaling_range[1]
+        return val * max_speed
 
 
 def main(args=None):

--- a/reseq_ros2/reseq_ros2/pivot_controller.py
+++ b/reseq_ros2/reseq_ros2/pivot_controller.py
@@ -1,0 +1,102 @@
+import rclpy
+from geometry_msgs.msg import Twist
+from rclpy.node import Node
+
+from reseq_interfaces.msg import Motors, Remote
+
+
+class PivotController(Node):
+    def __init__(self):
+        super().__init__('pivot_controller')
+        self.subscription = self.create_subscription(Remote, '/remote', self.remote_callback, 10)
+        self.cmd_vel_pub = self.create_publisher(Twist, '/cmd_vel', 10)
+
+        # publishers for direct motor control (otherwise all modules start moving)
+        self.motor_pub_module_first = self.create_publisher(
+            Motors, '/reseq/module17/motor/setpoint', 10
+        )
+        self.motor_pub_module_last = self.create_publisher(
+            Motors, '/reseq/module19/motor/setpoint', 10
+        )
+
+        self.increment = 0.1
+        self.pivot_on_first_module = True
+        self.is_pivot_mode = False
+        self.prev_blue_pressed = False
+
+    def remote_callback(self, msg: Remote):
+        buttons = msg.buttons if len(msg.buttons) >= 6 else [False] * 6
+        blue_pressed = buttons[5]
+        joystick_active = abs(msg.right.x) > 0.001
+
+        self.get_logger().info(f'[REMOTE] right.x = {msg.right.x}')
+
+        if blue_pressed and not self.prev_blue_pressed:
+            self.get_logger().info('Pivot mode activated')
+            self.stop_agevar()
+
+            if len(buttons) > 4:
+                self.pivot_on_first_module = not buttons[4]
+                self.get_logger().info(
+                    f'Pivoting on {"first" if self.pivot_on_first_module else "last"} module (switch state = {buttons[4]})'
+                )
+            self.is_pivot_mode = True
+
+        elif not blue_pressed and self.prev_blue_pressed:
+            self.get_logger().info('Pivot mode deactivated')
+            self.resume_agevar()
+            self.is_pivot_mode = False
+
+        if self.is_pivot_mode and blue_pressed and joystick_active:
+            self.handle_pivot(msg.right.x)
+
+        if self.is_pivot_mode and len(buttons) > 4:
+            new_state = not buttons[4]
+            if new_state != self.pivot_on_first_module:
+                self.pivot_on_first_module = new_state
+                self.get_logger().info(
+                    f'Pivot target changed to {"first" if self.pivot_on_first_module else "last"} module (switch state = {buttons[4]})'
+                )
+
+        self.prev_blue_pressed = blue_pressed
+
+    def resume_agevar(self):
+        resume_msg = Twist()
+        resume_msg.linear.x = 0.001
+        self.cmd_vel_pub.publish(resume_msg)
+        self.get_logger().info('Published resume command to /cmd_vel to resume AGeVaR.')
+
+    def stop_agevar(self):
+        stop_msg = Twist()
+        self.cmd_vel_pub.publish(stop_msg)
+        self.get_logger().info('Published zero velocity to /cmd_vel to stop AGeVaR.')
+
+    def handle_pivot(self, joystick_value):
+        self.get_logger().info(f'[PIVOT] Joystick value: {joystick_value}')
+        delta = max(min(joystick_value, 1.0), -1.0) * self.increment
+
+        pivot_msg = Motors()
+        pivot_msg.left = -delta
+        pivot_msg.right = delta
+
+        if self.pivot_on_first_module:
+            self.motor_pub_module_first.publish(pivot_msg)
+        else:
+            self.motor_pub_module_last.publish(pivot_msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    pivot_controller = PivotController()
+    try:
+        rclpy.spin(pivot_controller)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        pivot_controller.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/reseq_ros2/reseq_ros2/pivot_controller.py
+++ b/reseq_ros2/reseq_ros2/pivot_controller.py
@@ -1,163 +1,102 @@
-import rclpy
-from rclpy.node import Node
+import traceback
 
-from reseq_interfaces.msg import Motors, Remote
+import rclpy
+from geometry_msgs.msg import Twist
+from rclpy.node import Node
+from std_srvs.srv import SetBool
+
+import reseq_ros2.constants as rc
+from reseq_interfaces.msg import Motors
 
 
 class PivotController(Node):
     def __init__(self):
         super().__init__('pivot_controller')
-        self.subscription = self.create_subscription(Remote, '/remote', self.remote_callback, 10)
+
+        addresses = (
+            self.declare_parameter('modules', [0]).get_parameter_value().integer_array_value
+        )
+        self.d = self.declare_parameter('d', 0.0).get_parameter_value().double_value
+        self.r_eq = self.declare_parameter('r_eq', 0.0).get_parameter_value().double_value
 
         # Publishers for sending motor commands to individual modules
-        # These are targeted directly to avoid affecting other modules
-        self.motor_pub_module_first = self.create_publisher(
-            Motors, '/reseq/module17/motor/setpoint', 10
+        self.head_publisher = self.create_publisher(
+            Motors, f'/reseq/module{min(addresses)}/motor/setpoint', 10
         )
-        self.motor_pub_module_last = self.create_publisher(
-            Motors, '/reseq/module19/motor/setpoint', 10
-        )
-
-        # Declare max motor speed (used for scaling pivot velocity range)
-        # I think it's 65 but I'm not sure, it's what I read in the outline docs
-        self.max_motor_speed = (
-            self.declare_parameter('max_motor_speed', 65.0).get_parameter_value().double_value
+        self.tail_publisher = self.create_publisher(
+            Motors, f'/reseq/module{max(addresses)}/motor/setpoint', 10
         )
 
-        # Define range of motor velocities during pivot, based on max speed
-        self.pivot_velocity_range = [-self.max_motor_speed, self.max_motor_speed]
+        self.create_subscription(Twist, '/cmd_vel', self.remote_callback, 10)
 
-        # Controls whether pivoting is on the first or last module
-        self.pivot_on_first_module = True
+        self.enabled = False
+        self.pivot_on_head = True
+        self.create_service(SetBool, 'enable', self.handle_enable)
+        self.create_service(SetBool, 'pivot_on_head', self.handle_pivot_on_head)
 
-        # Tracks whether pivot mode is currently active
-        self.is_pivot_mode = False
+    def handle_enable(
+        self, request: SetBool.Request, response: SetBool.Response
+    ) -> SetBool.Response:
+        self.enabled = request.data
+        response.success = True
+        response.message = (
+            'Pivot controller enabled' if self.enabled else 'Pivot controller disabled'
+        )
+        self.get_logger().info(response.message)
 
-        # Used to detect transitions in the blue button state (pressed/released)
-        self.prev_blue_pressed = False
+        self.head_publisher.publish(Motors())
+        self.tail_publisher.publish(Motors())
 
-        # Timer to periodically resend pivot commands if the joystick is held
-        self.timer = self.create_timer(0.1, self.periodic_pivot_update)
+        return response
 
-        # Stores last joystick velocity to maintain command while pivoting
-        self.last_velocity = 0.0
+    def handle_pivot_on_head(
+        self, request: SetBool.Request, response: SetBool.Response
+    ) -> SetBool.Response:
+        self.pivot_on_head = request.data
+        response.success = True
+        response.message = 'Pivoting on head' if self.pivot_on_head else 'Pivoting on tail'
+        self.get_logger().info(response.message)
 
-    def remote_callback(self, msg: Remote):
-        buttons = msg.buttons if len(msg.buttons) >= 6 else [False] * 6
-        blue_pressed = buttons[5]
-        joystick_active = abs(msg.right.x) > 0.001  # dead zone threshold
+        self.head_publisher.publish(Motors())
+        self.tail_publisher.publish(Motors())
 
-        self.get_logger().info(f'[REMOTE] right.x = {msg.right.x}')
+        return response
 
-        if blue_pressed and not self.prev_blue_pressed:
-            self.get_logger().info('Pivot mode activated')
+    def remote_callback(self, msg: Twist):
+        if not self.enabled:
+            self.get_logger().debug('Pivot controller is disabled. Skipping command.')
+            return
 
-            # Check toggle button for module selection
-            if len(buttons) > 4:
-                self.pivot_on_first_module = not buttons[4]
-                self.get_logger().info(
-                    f'Pivoting on {"first" if self.pivot_on_first_module else "last"} module '
-                    f'(switch state = {buttons[4]})'
-                )
-            self.is_pivot_mode = True
+        ang_speed = msg.angular.z
 
-        # Detect falling edge of blue button to deactivate pivot mode
-        elif not blue_pressed and self.prev_blue_pressed:
-            self.get_logger().info('Pivot mode deactivated')
-            self.is_pivot_mode = False
+        # differential drive with V=0
+        m = Motors
+        m.right = ang_speed * self.d / (2 * self.r_eq) * rc.rads2rpm
+        m.left = -m.right
 
-        # While pivot mode is active and blue button is held
-        if self.is_pivot_mode and blue_pressed:
-            if joystick_active:
-                # Handle pivot movement based on joystick input
-                self.handle_pivot(msg.right.x)
-            else:
-                # Stop motors if joystick is idle
-                stop_msg = Motors()
-                stop_msg.left = 0.0
-                stop_msg.right = 0.0
-                if self.pivot_on_first_module:
-                    self.motor_pub_module_first.publish(stop_msg)
-                else:
-                    self.motor_pub_module_last.publish(stop_msg)
+        self.get_logger().debug(
+            f"Pivoting {'on head' if self.pivot_on_head else 'on tail'} with values: R={m.right}, L={m.left}"  # noqa
+        )
 
-        # Check for module switch change during pivot mode
-        if self.is_pivot_mode and len(buttons) > 4:
-            new_state = not buttons[4]
-            if new_state != self.pivot_on_first_module:
-                # send stop command to the previously active module
-                stop_msg = Motors()
-                stop_msg.left = 0.0
-                stop_msg.right = 0.0
-
-                if self.pivot_on_first_module:
-                    self.motor_pub_module_first.publish(stop_msg)
-                else:
-                    self.motor_pub_module_last.publish(stop_msg)
-
-                # now update the target
-                self.pivot_on_first_module = new_state
-                self.get_logger().info(
-                    'Pivot target changed to '
-                    f'{"first" if self.pivot_on_first_module else "last"} module '
-                    f'(switch state = {buttons[4]})'
-                )
-
-        # Store current blue button state for edge detection in next call
-        self.prev_blue_pressed = blue_pressed
-
-    def handle_pivot(self, joystick_value):
-        self.get_logger().info(
-            f'[PIVOT] Joystick value: {joystick_value}'
-        )  # here for debugging purposes
-
-        # Convert joystick value to motor speed using scaling function
-        velocity = self.scale(joystick_value, self.pivot_velocity_range)
-        self.last_velocity = velocity
-        self.get_logger().info(
-            f'[PIVOT] Scaled velocity: {velocity}'
-        )  # here for debugging purposes
-
-        # Create pivot motor message (opposite directions for pivoting)
-        pivot_msg = Motors()
-        pivot_msg.left = velocity
-        pivot_msg.right = -velocity
-
-        # Publish to the appropriate module
-        if self.pivot_on_first_module:
-            self.motor_pub_module_first.publish(pivot_msg)
+        if self.pivot_on_head:
+            self.head_publisher.publish(m)
         else:
-            self.motor_pub_module_last.publish(pivot_msg)
-
-    # This function is probably not necessary at all, but let's be safe
-    def periodic_pivot_update(self):
-        if self.is_pivot_mode and abs(self.last_velocity) > 0.01:
-            pivot_msg = Motors()
-            pivot_msg.left = self.last_velocity
-            pivot_msg.right = -self.last_velocity
-            if self.pivot_on_first_module:
-                self.motor_pub_module_first.publish(pivot_msg)
-            else:
-                self.motor_pub_module_last.publish(pivot_msg)
-
-    def scale(self, val, scaling_range):
-        # Clamp joystick input and scale it to motor speed range
-        val = max(min(val, 1.0), -1.0)
-        max_speed = scaling_range[1]
-        return val * max_speed
+            self.tail_publisher.publish(m)
 
 
 def main(args=None):
     rclpy.init(args=args)
-    pivot_controller = PivotController()
     try:
+        pivot_controller = PivotController()
         rclpy.spin(pivot_controller)
-    except KeyboardInterrupt:
-        pass
-    finally:
+    except Exception as err:
+        rclpy.logging.get_logger('pivot_controller').fatal(
+            f'Error in the Agevar node: {str(err)}\n{traceback.format_exc()}'
+        )
+        raise err
+    else:
         pivot_controller.destroy_node()
-        if rclpy.ok():
-            rclpy.shutdown()
+        rclpy.shutdown()
 
 
 if __name__ == '__main__':

--- a/reseq_ros2/reseq_ros2/scaler.py
+++ b/reseq_ros2/reseq_ros2/scaler.py
@@ -62,7 +62,7 @@ class Scaler(Node):
         self.enea_enabled = False
 
         # Declaring parameters and getting values
-        version = self.declare_parameter('version', '').get_parameter_value().string_value
+        version = self.declare_parameter('version', 'mk1').get_parameter_value().string_value
 
         self.r_linear_vel = (
             self.declare_parameter('r_linear_vel', [0.0]).get_parameter_value().double_array_value
@@ -107,6 +107,9 @@ class Scaler(Node):
         self.get_logger().info('Scaler node started')
 
     def handle_buttons(self, buttons: list[bool]):
+        if buttons == self.previous_buttons:
+            return
+
         for handler in self.handlers:
             if buttons[handler['button']] != self.previous_buttons[handler['button']]:
                 if 'condition' not in handler or handler['condition'](buttons):

--- a/reseq_ros2/reseq_ros2/scaler.py
+++ b/reseq_ros2/reseq_ros2/scaler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import traceback
 from enum import Enum, IntEnum
 
@@ -25,7 +27,7 @@ and an optional hook function to be executed after the service is called.
 class Scaler(Node):
     control_mode_enum: Enum = Enum('ControlMode', 'AGEVAR, PIVOT')
     buttons_enum: IntEnum = IntEnum(
-        'Buttons', 'S1, S2, S3, S4, S5 BGREEN, BBLACK, BRED, BWHITE, BBLUE', start=0
+        'Buttons', 'S1, S2, S3, S4, S5, BGREEN, BBLACK, BRED, BWHITE, BBLUE', start=0
     )
 
     # OBSERVATIONS: The switches are zero in the upwards position,
@@ -115,7 +117,7 @@ class Scaler(Node):
                 if 'condition' not in handler or handler['condition'](buttons):
                     data = handler['inverted'] ^ buttons[handler['button']]
                     handler['service'].call_async(SetBool.Request(data=data))
-                    if 'hook' in handler:
+                    if 'hook' in handler and data:
                         handler['hook'](self)
                     self.get_logger().debug(
                         f"Called service '{handler['name']}' for {handler['button'].name}={buttons[handler['button']]}, value={data}"  # noqa

--- a/reseq_ros2/setup.py
+++ b/reseq_ros2/setup.py
@@ -34,6 +34,7 @@ setup(
             'joint_publisher = reseq_ros2.joint_publisher:main',
             'feedback_replicator = reseq_ros2.feedback_replicator:main',
             'emulator_remote_controller = reseq_ros2.emulator_remote_controller:main',
+            'pivot_controller = reseq_ros2.pivot_controller:main',
         ],
     },
 )

--- a/reseq_ros2/test/test_nodes/test_scaler/test_scaler_functional.py
+++ b/reseq_ros2/test/test_nodes/test_scaler/test_scaler_functional.py
@@ -23,8 +23,10 @@ class TestScalerFunctional(unittest.TestCase):
 
         # Expected parameter values from scaler_consts.yaml
         cls.expected_params = {
+            'version': 'mk1',
             'r_linear_vel': [-0.27017, 0.27017],
             'r_inverse_radius': [-1.5385, 1.5385],
+            'r_angular_vel': [-2.8387, 2.8387],
             'r_pitch_vel': [-183, 183],
             'r_head_pitch_vel': [-400, 400],
             'r_head_roll_vel': [-455, 455],
@@ -149,6 +151,16 @@ class TestScalerFunctional(unittest.TestCase):
                     rclpy.Parameter.Type.INTEGER_ARRAY,
                     self.expected_params['r_head_roll_vel'],
                 ),
+                Parameter(
+                    'version',
+                    rclpy.Parameter.Type.STRING,
+                    self.expected_params['version'],
+                ),
+                Parameter(
+                    'r_angular_vel',
+                    rclpy.Parameter.Type.DOUBLE_ARRAY,
+                    self.expected_params['r_angular_vel'],
+                ),
             ]
         )
 
@@ -158,6 +170,7 @@ class TestScalerFunctional(unittest.TestCase):
         remote_msg.left.y = 1.0
         remote_msg.left.z = 0.7
         remote_msg.left.x = -0.3
+        remote_msg.buttons = [False, False, False, False, False, True, True, True, True, True]
 
         # Capture published messages
         self.cmd_vel_msg = None

--- a/reseq_ros2/test/test_nodes/test_scaler/test_scaler_launch.py
+++ b/reseq_ros2/test/test_nodes/test_scaler/test_scaler_launch.py
@@ -55,6 +55,8 @@ class TestScalerLaunch(unittest.TestCase):
         cls.expected_params = {
             'r_linear_vel': [-0.27017, 0.27017],
             'r_inverse_radius': [-1.5385, 1.5385],
+            'r_angular_vel': [-2.8387, 2.8387],
+            'version': 'mk1',
             'r_pitch_vel': [-183, 183],
             'r_head_pitch_vel': [-400, 400],
             'r_head_roll_vel': [-455, 455],

--- a/reseq_ros2/test/test_system/test_node_communication.py
+++ b/reseq_ros2/test/test_system/test_node_communication.py
@@ -37,6 +37,7 @@ class TestNodes(unittest.TestCase):
         cls.msg = Remote()
         cls.msg.left = Vector3(x=0.5, y=-0.2, z=1.0)
         cls.msg.right = Vector3(x=-0.8, y=0.3, z=0.7)
+        cls.msg.buttons = [False, False, False, False, False, True, True, True, True, True]
 
         cls.address = 17
 

--- a/reseq_ros2/test/test_system/test_topic_correctness.py
+++ b/reseq_ros2/test/test_system/test_topic_correctness.py
@@ -138,6 +138,7 @@ class TestNodes(unittest.TestCase):
         cls.msg = Remote()
         cls.msg.left = Vector3(x=0.5, y=-0.2, z=1.0)
         cls.msg.right = Vector3(x=-0.8, y=0.3, z=0.7)
+        cls.msg.buttons = [False, False, False, False, False, True, True, True, True, True]
 
         # Initialize the CAN bus interface
         if cls.stat[0]:
@@ -225,8 +226,7 @@ class TestNodes(unittest.TestCase):
             '/remote': reseq_interfaces.msg.Remote(
                 left=geometry_msgs.msg.Vector3(x=0.5, y=-0.2, z=1.0),
                 right=geometry_msgs.msg.Vector3(x=-0.8, y=0.3, z=0.7),
-                buttons=[],
-                switches=[],
+                buttons=[False, False, False, False, False, True, True, True, True, True],
             ),
             '/reseq/module17/end_effector/head_pitch/setpoint': std_msgs.msg.Int32(data=800),
             '/reseq/module17/end_effector/head_roll/setpoint': std_msgs.msg.Int32(data=0),


### PR DESCRIPTION
**What This Does**

This adds a pivot mode to the robot, so it can rotate in place using just one module.

When the blue button (button 5) is held down and the right joystick is moved left or right, the robot enters pivot mode. In this mode:

- It (hopefully) stops AGeVaR by sending zero velocity to /cmd_vel
- Only one of the modules (either the first or the last) moves its tracks in opposite directions to pivot the robot in place
- Which module is used depends on the state of the rightmost switch (button 4). When it's toggled, the pivot module changes.

Once the blue button is released, the robot exits pivot mode and AGeVaR resumes again (hopefully).

The emulator controller was also updated (to match the needs of the new script):
- Pressing `m` simulates pressing the blue button
- Pressing `n` simulates releasing it
- Pressing `j` or `l` moves the right joystick left/right to trigger pivoting
- Pressing `u` toggles which module is used for pivoting

I simulated this script and it should be working the way I was instructed.