### PR TITLE
Fix arm URDF alignment

### DIFF
--- a/reseq_arm_mk2/urdf/reseq_arm_mk2.xacro
+++ b/reseq_arm_mk2/urdf/reseq_arm_mk2.xacro
@@ -46,16 +46,16 @@
     name="arm_diff_pitch_link">
     <inertial>
       <origin
-        xyz="-1.3878E-17 0.00059334 1.7347E-18"
+        xyz="-0.00059334 -1.3878E-17 3.4694E-18"
         rpy="0 0 0" />
       <mass
         value="0.28931" />
       <inertia
-        ixx="0.0002425"
-        ixy="-1.6941E-20"
-        ixz="-1.5531E-20"
-        iyy="0.00023577"
-        iyz="8.3058E-21"
+        ixx="0.00023577"
+        ixy="1.6941E-20"
+        ixz="-8.3058E-21"
+        iyy="0.0002425"
+        iyz="-1.5531E-20"
         izz="0.00025759" />
     </inertial>
     <visual>
@@ -87,7 +87,7 @@
     type="revolute">
     <origin
       xyz="0 0 0"
-      rpy="1.5708 -1.309 0" />
+      rpy="1.5708 0.2 0" />
     <parent
       link="arm_base_link" />
     <child
@@ -95,31 +95,32 @@
     <axis
       xyz="0 0 -1" />
     <limit
-      lower="-1.05"
-      upper="1.309"
+      lower="-0.1"
+      upper="2.8"
       effort="6"
       velocity="2" />
+    <dynamics damping="0.5" friction="0.1" />
   </joint>
   <link
     name="arm_diff_roll_link">
     <inertial>
       <origin
-        xyz="1.1115E-08 7.62E-08 -0.14664"
+        xyz="-0.14664 7.62E-08 -1.1115E-08"
         rpy="0 0 0" />
       <mass
         value="0.11865" />
       <inertia
-        ixx="0.00051345"
-        ixy="-2.7475E-10"
-        ixz="-9.7641E-11"
+        ixx="1.0228E-05"
+        ixy="2.2625E-10"
+        ixz="9.7641E-11"
         iyy="0.00051383"
-        iyz="2.2625E-10"
-        izz="1.0228E-05" />
+        iyz="2.7475E-10"
+        izz="0.00051345" />
     </inertial>
     <visual>
       <origin
         xyz="0 0 0"
-        rpy="0 0 0" />
+        rpy="0 1.5708 0" />
       <geometry>
         <mesh
           filename="package://reseq_arm_mk2/meshes/arm_diff_roll_link.STL" />
@@ -133,7 +134,7 @@
     <collision>
       <origin
         xyz="0 0 0"
-        rpy="0 0 0" />
+        rpy="0 1.5708 0" />
       <geometry>
         <mesh
           filename="package://reseq_arm_mk2/meshes/arm_diff_roll_link.STL" />
@@ -145,18 +146,19 @@
     type="revolute">
     <origin
       xyz="0 0 0"
-      rpy="1.5708 1.5708 0" />
+      rpy="0 0 0" />
     <parent
       link="arm_diff_pitch_link" />
     <child
       link="arm_diff_roll_link" />
     <axis
-      xyz="0 0 1" />
+      xyz="1 0 0" />
     <limit
       lower="-3.14"
       upper="3.14"
       effort="6"
       velocity="2" />
+    <dynamics damping="0.5" friction="0.1" />
   </joint>
   <link
     name="arm_pitch_forearm_link">
@@ -169,9 +171,9 @@
       <inertia
         ixx="4.6765E-05"
         ixy="-9.086E-05"
-        ixz="1.3681E-20"
+        ixz="1.3572E-20"
         iyy="0.00027451"
-        iyz="3.2975E-21"
+        iyz="3.2775E-21"
         izz="0.00031255" />
     </inertial>
     <visual>
@@ -202,8 +204,8 @@
     name="mod1__elbow_pitch_arm_joint"
     type="revolute">
     <origin
-      xyz="0 0 -0.28857"
-      rpy="3.1416 -1.5708 3.1416" />
+      xyz="-0.28857 0 0"
+      rpy="0 0 0.2" />
     <parent
       link="arm_diff_roll_link" />
     <child
@@ -211,10 +213,11 @@
     <axis
       xyz="0 0 1" />
     <limit
-      lower="-1.05"
+      lower="-0.1"
       upper="2.88"
       effort="6"
       velocity="2" />
+    <dynamics damping="0.5" friction="0.1" />
   </joint>
   <link
     name="arm_roll_forearm_link">
@@ -226,8 +229,8 @@
         value="0.096867" />
       <inertia
         ixx="5.2065E-05"
-        ixy="1.6912E-22"
-        ixz="-6.5731E-21"
+        ixy="1.7168E-22"
+        ixz="-6.5851E-21"
         iyy="4.9885E-05"
         iyz="2.3291E-07"
         izz="2.3052E-05" />
@@ -261,7 +264,7 @@
     type="revolute">
     <origin
       xyz="0.15351 0.074002 0"
-      rpy="0.2618 -1.5708 3.1416" />
+      rpy="0.2618 -1.5708 3.14" />
     <parent
       link="arm_pitch_forearm_link" />
     <child
@@ -273,27 +276,28 @@
       upper="3.14"
       effort="3"
       velocity="1" />
+    <dynamics damping="0.5" friction="0.1" />
   </joint>
   <link
     name="arm_pitch_wrist_link">
     <inertial>
       <origin
-        xyz="0.045311 1.3878E-17 -3.296E-17"
+        xyz="5.3776E-17 2.7756E-17 0.045311"
         rpy="0 0 0" />
       <mass
         value="0.056876" />
       <inertia
-        ixx="1.5222E-05"
-        ixy="2.5626E-21"
-        ixz="3.1474E-21"
+        ixx="1.6114E-05"
+        ixy="3.0569E-22"
+        ixz="-3.5109E-21"
         iyy="2.2881E-05"
-        iyz="-1.4326E-21"
-        izz="1.6114E-05" />
+        iyz="1.0674E-21"
+        izz="1.5222E-05" />
     </inertial>
     <visual>
       <origin
         xyz="0 0 0"
-        rpy="0 0 0" />
+        rpy="0 -1.5708 0" />
       <geometry>
         <mesh
           filename="package://reseq_arm_mk2/meshes/arm_pitch_wrist_link.STL" />
@@ -307,7 +311,7 @@
     <collision>
       <origin
         xyz="0 0 0"
-        rpy="0 0 0" />
+        rpy="0 -1.5708 0" />
       <geometry>
         <mesh
           filename="package://reseq_arm_mk2/meshes/arm_pitch_wrist_link.STL" />
@@ -319,18 +323,19 @@
     type="revolute">
     <origin
       xyz="0 0 0.05447"
-      rpy="3.1416 -1.5708 3.1416" />
+      rpy="-0.25 0 0" />
     <parent
       link="arm_roll_forearm_link" />
     <child
       link="arm_pitch_wrist_link" />
     <axis
-      xyz="0 0 -1" />
+      xyz="-1 0 0" />
     <limit
       lower="-0.46"
       upper="1.57"
       effort="3"
       velocity="1" />
+    <dynamics damping="0.5" friction="0.1" />
   </joint>
   <link
     name="arm_roll_wrist_link">
@@ -342,8 +347,8 @@
         value="0.55801" />
       <inertia
         ixx="0.00046764"
-        ixy="1.372E-19"
-        ixz="1.5587E-19"
+        ixy="1.3696E-19"
+        ixz="1.5471E-19"
         iyy="0.000956"
         iyz="7.6437E-06"
         izz="0.00082011" />
@@ -377,7 +382,7 @@
     type="revolute">
     <origin
       xyz="0 0 0"
-      rpy="0 1.5708 0" />
+      rpy="0 0 0" />
     <parent
       link="arm_pitch_wrist_link" />
     <child
@@ -389,5 +394,35 @@
       upper="3.14"
       effort="3"
       velocity="1" />
+    <dynamics damping="0.5" friction="0.1" />
   </joint>
+
+  <gazebo reference="arm_base_link">
+    <material>Gazebo/Grey</material>
+    <selfCollide>false</selfCollide>
+  </gazebo>
+  <gazebo reference="arm_diff_pitch_link">
+    <material>Gazebo/Grey</material>
+    <selfCollide>false</selfCollide>
+  </gazebo>
+  <gazebo reference="arm_diff_roll_link">
+    <material>Gazebo/Grey</material>
+    <selfCollide>false</selfCollide>
+  </gazebo>
+  <gazebo reference="arm_pitch_forearm_link">
+    <material>Gazebo/Grey</material>
+    <selfCollide>false</selfCollide>
+  </gazebo>
+  <gazebo reference="arm_roll_forearm_link">
+    <material>Gazebo/Grey</material>
+    <selfCollide>false</selfCollide>
+  </gazebo>
+  <gazebo reference="arm_pitch_wrist_link">
+    <material>Gazebo/Grey</material>
+    <selfCollide>false</selfCollide>
+  </gazebo>
+  <gazebo reference="arm_roll_wrist_link">
+    <material>Gazebo/Grey</material>
+    <selfCollide>false</selfCollide>
+  </gazebo>
 </robot>


### PR DESCRIPTION
## Summary

Fixes the ReseQ MK2 arm visualization in Gazebo and updates the outdated Gazebo documentation on Outline.
## What changed

 - Corrected the arm mesh alignment/pose issues in the MK2 arm URDF/Xacro.
 -  Added Gazebo-specific joint damping/friction and self-collision settings for more stable simulation.

Closes https://github.com/Team-Isaac-Polito/reseq_ros2/issues/99