### PR TITLE
Refactor Dockerfile.orin dependency layers #110

### DIFF
--- a/docker/Dockerfile.orin
+++ b/docker/Dockerfile.orin
@@ -1,7 +1,14 @@
-# Build the docker in ~/ros2_ws directory:
-# docker build -t reseq-orin -f src/docker/Dockerfile.orin src
+# Build from the repository root:
+# docker build -t reseq-orin -f docker/Dockerfile.orin .
+# Slimmer build without debug/visualization tools:
+# docker build -t reseq-orin -f docker/Dockerfile.orin --build-arg INSTALL_DEV_TOOLS=false .
 # Run the docker:
 # docker run -it --rm --privileged --volume /lib/modules:/lib/modules:ro --volume /usr/src:/usr/src:ro --runtime nvidia --gpus all --network host -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v /home/isaac/.Xauthority:/root/.Xauthority:ro --entrypoint /bin/bash reseq-orin
+#
+# Build stages:
+# - nvidia-realsense: Jetson, CUDA, ROS and librealsense base
+# - reseq-base: RESE.Q runtime extras plus optional debug tooling
+# - reseq: workspace checkout, rosdep resolution and colcon build
 
 # --- See https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common/blob/release-3.1/docker/Dockerfile.aarch64 for the source of the code
 # (ends in line 270)
@@ -31,7 +38,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
 apt-get update && apt-get install -y \
         software-properties-common \
 && add-apt-repository universe \
-&& apt-get update
+&& apt-get update \
+&& rm -rf /var/lib/apt/lists/*
 
 # Fundamentals
 RUN --mount=type=cache,target=/var/cache/apt \
@@ -54,14 +62,16 @@ apt-get update && apt-get install -y \
     unzip \
     vim \
     wget \
-    zlib1g-dev
+    zlib1g-dev \
+&& rm -rf /var/lib/apt/lists/*
 
 # Add Isaac apt repository
 RUN --mount=type=cache,target=/var/cache/apt \
     wget -qO - https://isaac.download.nvidia.com/isaac-ros/repos.key | apt-key add - && \
     grep -qxF "deb https://isaac.download.nvidia.com/isaac-ros/release-3 $(lsb_release -cs) legacy-release-3.1" /etc/apt/sources.list || \
     echo "deb https://isaac.download.nvidia.com/isaac-ros/release-3 $(lsb_release -cs) legacy-release-3.1" | tee -a /etc/apt/sources.list \
-    && apt-get update
+    && apt-get update \
+    && rm -rf /var/lib/apt/lists/*
 
 # Setup Jetson debian repositories
 RUN --mount=type=cache,target=/var/cache/apt \
@@ -69,7 +79,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
     && apt-key adv --fetch-keys http://l4t-repo.nvidia.com/jetson-ota-internal.key \
     && echo 'deb https://repo.download.nvidia.com/jetson/common r36.3 main' > /etc/apt/sources.list.d/nvidia-l4t-apt-source.list \
     && echo 'deb https://repo.download.nvidia.com/jetson/t234 r36.3 main' >> /etc/apt/sources.list.d/nvidia-l4t-apt-source.list \
-    && apt-get update
+    && apt-get update \
+    && rm -rf /var/lib/apt/lists/*
 
 # Python basics
 RUN --mount=type=cache,target=/var/cache/apt \
@@ -82,7 +93,8 @@ apt-get update && apt-get install -y \
     python3-venv \
     python3-zmq \
     python3.10 \
-    python3.10-venv
+    python3.10-venv \
+&& rm -rf /var/lib/apt/lists/*
 
 # Set Python3 as default
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
@@ -134,7 +146,8 @@ apt-get update && apt-get install -y \
     llvm-14 \
     nlohmann-json3-dev \
     python3-opencv=4.5.4+dfsg-9ubuntu4 \
-    python3-scipy
+    python3-scipy \
+&& rm -rf /var/lib/apt/lists/*
 
 # Python buildtools
 RUN python3 -m pip install -U \
@@ -187,7 +200,8 @@ apt-get update && apt-get install -y --no-install-recommends \
     libcublas-12-2 \
     libcudnn8 \
     libcusparse-12-2 \
-    libnpp-12-2
+    libnpp-12-2 \
+&& rm -rf /var/lib/apt/lists/*
 
 # Install TensorRT and VPI
 RUN --mount=type=cache,target=/var/cache/apt \
@@ -195,7 +209,8 @@ mkdir -p /lib/firmware && \
 apt-get update && apt-get install -y \
     libnvvpi3 \
     tensorrt \
-    vpi3-dev
+    vpi3-dev && \
+rm -rf /var/lib/apt/lists/*
 
 # Install Tao converter
 RUN mkdir -p /opt/nvidia/tao && cd /opt/nvidia/tao && \
@@ -218,7 +233,8 @@ apt-get update && apt-get install -y --no-install-recommends \
     libre2-9 \
     rapidjson-dev \
     libopenblas-dev \
-    libarchive-dev
+    libarchive-dev \
+&& rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/var/cache/apt \
     cd /opt \
@@ -254,7 +270,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
 apt-add-repository ppa:mosquitto-dev/mosquitto-ppa \
 && apt-get update && apt-get install -y \
         mosquitto \
-        mosquitto-clients
+        mosquitto-clients \
+&& rm -rf /var/lib/apt/lists/*
 
 # Install jtop
 RUN python3 -m pip install -U \
@@ -264,7 +281,8 @@ RUN python3 -m pip install -U \
 # Upgrade system packages for security patches
 RUN --mount=type=cache,target=/var/cache/apt \
 apt-get update && apt-get install -y \
-        nghttp2=1.43.0-1ubuntu0.2
+        nghttp2=1.43.0-1ubuntu0.2 \
+&& rm -rf /var/lib/apt/lists/*
 
 # Store list of packages (must be last)
 RUN mkdir -p /opt/nvidia/isaac_ros_dev_base && dpkg-query -W | sort > /opt/nvidia/isaac_ros_dev_base/aarch64-end-packages.csv
@@ -328,7 +346,8 @@ RUN apt-get update \
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     python3-rosdep \
-    python3-colcon-common-extensions
+    python3-colcon-common-extensions \
+ && rm -rf /var/lib/apt/lists/*
 
 # See https://github.com/NVIDIA-ISAAC-ROS/realsense-ros for realsense-ros2 installation
 # 1. Define build arguments
@@ -341,45 +360,49 @@ ENV ROS_ROOT=/opt/ros/${ROS_DISTRO}
 COPY docker/utils/ros_entrypoint.sh /ros_entrypoint.sh
 
 # 2. Clone, build, and install realsense-ros
-RUN apt update && rosdep init && rosdep update && source /ros_entrypoint.sh && \
+RUN apt-get update && rosdep init && rosdep update && source /ros_entrypoint.sh && \
     mkdir -p /realsense-ros/src && cd /realsense-ros/src && \
     git clone ${REALSENSE_ROS_GIT_URL} -b ${REALSENSE_ROS_VERSION} ros2-development && cd /realsense-ros && \
     rosdep install -i --from-path src --rosdistro $ROS_DISTRO --skip-keys=librealsense2 -y && \
     colcon build && \
-    sed -i "\$i ros_source_env /realsense-ros/install/setup.bash \n" /ros_entrypoint.sh
+    sed -i "\$i ros_source_env /realsense-ros/install/setup.bash \n" /ros_entrypoint.sh && \
+    rm -rf /var/lib/apt/lists/*
 
 CMD /bin/bash -c "source $ROS_ROOT/setup.bash && cd ~/realsense-ros && . install/local_setup.bash"
 
 # ROS2 and Ultralytics setup
 FROM nvidia-realsense AS reseq-base
 
-RUN apt update && apt install -y --no-install-recommends \
-    ros-humble-xacro \
-    ros-humble-image-transport-plugins \
-    ros-humble-rplidar-ros \
-    ros-humble-rosbridge-server \
-    ros-humble-usb-cam \
-    ros-humble-controller-manager \
-    ros-humble-diff-drive-controller \
-    ros-humble-joint-state-broadcaster \
-    ros-humble-slam-toolbox \
-    ros-humble-ros2-control-test-assets \
-    ros-humble-geometry-msgs \
-    ros-humble-moveit-ros-move-group \
-    ros-humble-moveit-servo \
-    ros-humble-moveit-configs-utils \
-    ros-humble-moveit-planners-ompl \
-    ros-humble-moveit-kinematics \
-    ros-humble-pick-ik \
-    # for visualizations and debugging
-    ros-humble-rqt \
-    ros-humble-rqt-common-plugins \
-    ros-humble-rqt-image-view \
-    ros-humble-rviz2
+ARG INSTALL_DEV_TOOLS=true
 
-# Install Ultralytics
-RUN pip install ultralytics --no-cache-dir \
-    # Download PyTorch, TorchVision, and ONNX Runtime GPU wheels for JetPack 6.0 / CUDA 12.2
+# Keep only image-specific extras here; workspace-declared ROS packages are
+# resolved by rosdep in the final stage from the checked-out package.xml files.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-humble-rosbridge-server \
+    ros-humble-slam-toolbox \
+    iproute2 \
+    usbutils \
+    python3-libnvinfer-dev \
+ && if [ "$INSTALL_DEV_TOOLS" = "true" ]; then \
+        apt-get install -y --no-install-recommends \
+            nano \
+            ranger \
+            ros-humble-rqt \
+            ros-humble-rqt-common-plugins \
+            ros-humble-rqt-image-view \
+            ros-humble-rviz2; \
+    fi \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Ultralytics and RESE.Q Python runtime extras.
+# Download PyTorch, TorchVision, and ONNX Runtime GPU wheels for JetPack 6.0 / CUDA 12.2.
+RUN pip install --no-cache-dir \
+        ultralytics \
+        opencv-contrib-python \
+        numpy==1.23.5 \
+        Jetson.GPIO \
+        adafruit-circuitpython-mlx90640 \
+        adafruit-blinka \
     && wget https://nvidia.box.com/shared/static/mp164asf3sceb570wvjsrezk1p4ftj8t.whl -O torch-2.3.0-cp310-cp310-linux_aarch64.whl \
     && wget https://nvidia.box.com/shared/static/u0ziu01c0kyji4zz3gxam79181nebylf.whl -O torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl \
     && wget https://nvidia.box.com/shared/static/48dtuob7meiw6ebgfsfqakc9vse62sg4.whl -O onnxruntime_gpu-1.18.0-cp310-cp310-linux_aarch64.whl \
@@ -388,24 +411,13 @@ RUN pip install ultralytics --no-cache-dir \
     && pip install torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl \
     && pip install onnxruntime_gpu-1.18.0-cp310-cp310-linux_aarch64.whl \
     && rm *.whl \
-    \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends python3-libnvinfer-dev \
-    \
     && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/arm64/cuda-keyring_1.1-1_all.deb \
     && dpkg -i cuda-keyring_1.1-1_all.deb \
     && apt-get update \
     && apt-get -y install libcusparselt0 libcusparselt-dev \
     && rm cuda-keyring_1.1-1_all.deb \
-    \
-    && pip install numpy==1.23.5 \
-    \
+    && rm -rf /var/lib/apt/lists/* \
     && echo "Ultralytics and dependencies successfully installed using JetPack 6.0 compatible wheels."
-
-RUN apt update --allow-releaseinfo-change && apt install -y --no-install-recommends \
-    iproute2 ros-humble-apriltag-ros usbutils ranger nano \
-    && pip install opencv-contrib-python numpy==1.23.5 \
-    && pip install Jetson.GPIO adafruit-circuitpython-mlx90640 adafruit-blinka
 
 # Final stage: build reseq_ros2
 FROM reseq-base AS reseq
@@ -413,11 +425,12 @@ FROM reseq-base AS reseq
 RUN mkdir -p /ros2_ws
 WORKDIR /ros2_ws
 
-RUN apt update && \
+RUN apt-get update && \
     git clone --recursive https://github.com/Team-Isaac-Polito/reseq_ros2.git src && \
     cd src && git submodule update --recursive --remote && cd .. && \
-    source /ros_entrypoint.sh && \ 
+    source /ros_entrypoint.sh && \
     rosdep install -i --from-path src --rosdistro $ROS_DISTRO --skip-keys="librealsense2 realsense2_camera" -y -t exec -t build && \
     colcon build && \
     sed -i "\$i ros_source_env /ros2_ws/install/setup.bash \n" /ros_entrypoint.sh && \
-    sed -i "\$i source /ros_entrypoint.sh \n" /root/.bashrc
+    sed -i "\$i source /ros_entrypoint.sh \n" /root/.bashrc && \
+    rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.orin
+++ b/docker/Dockerfile.orin
@@ -23,14 +23,14 @@
 
 # Docker file for aarch64 based Jetson device
 ARG BASE_IMAGE="nvcr.io/nvidia/l4t-cuda:12.2.12-devel"
-FROM ${BASE_IMAGE} as nvidia-realsense
+FROM ${BASE_IMAGE} AS nvidia-realsense
 
 # Store list of packages (must be first)
 RUN mkdir -p /opt/nvidia/isaac_ros_dev_base && dpkg-query -W | sort > /opt/nvidia/isaac_ros_dev_base/aarch64-start-packages.csv
 
 # Disable terminal interaction for apt
 ENV DEBIAN_FRONTEND=noninteractive
-ENV SHELL /bin/bash
+ENV SHELL=/bin/bash
 SHELL ["/bin/bash", "-c"]
 
 # Ensure we have universe
@@ -378,8 +378,26 @@ ARG INSTALL_DEV_TOOLS=true
 # Keep only image-specific extras here; workspace-declared ROS packages are
 # resolved by rosdep in the final stage from the checked-out package.xml files.
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-humble-xacro \
+    ros-humble-image-transport-plugins \
+    ros-humble-rplidar-ros \
     ros-humble-rosbridge-server \
+    ros-humble-usb-cam \
+    ros-humble-controller-manager \
+    ros-humble-diff-drive-controller \
+    ros-humble-joint-state-broadcaster \
     ros-humble-slam-toolbox \
+    ros-humble-ros2-control-test-assets \
+    ros-humble-geometry-msgs \
+    ros-humble-moveit-ros-move-group \
+    ros-humble-moveit-servo \
+    ros-humble-moveit-configs-utils \
+    ros-humble-moveit-planners-ompl \
+    ros-humble-moveit-kinematics \
+    ros-humble-pick-ik \
+    ros-humble-ros2controlcli \
+    ros-humble-forward-command-controller \
+    ros-humble-velocity-controllers \
     iproute2 \
     usbutils \
     python3-libnvinfer-dev \
@@ -399,14 +417,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir \
         ultralytics \
         opencv-contrib-python \
-        numpy==1.23.5 \
         Jetson.GPIO \
         adafruit-circuitpython-mlx90640 \
         adafruit-blinka \
     && wget https://nvidia.box.com/shared/static/mp164asf3sceb570wvjsrezk1p4ftj8t.whl -O torch-2.3.0-cp310-cp310-linux_aarch64.whl \
     && wget https://nvidia.box.com/shared/static/u0ziu01c0kyji4zz3gxam79181nebylf.whl -O torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl \
     && wget https://nvidia.box.com/shared/static/48dtuob7meiw6ebgfsfqakc9vse62sg4.whl -O onnxruntime_gpu-1.18.0-cp310-cp310-linux_aarch64.whl \
-    \
     && pip install torch-2.3.0-cp310-cp310-linux_aarch64.whl \
     && pip install torchvision-0.18.0a0+6043bc2-cp310-cp310-linux_aarch64.whl \
     && pip install onnxruntime_gpu-1.18.0-cp310-cp310-linux_aarch64.whl \
@@ -416,6 +432,7 @@ RUN pip install --no-cache-dir \
     && apt-get update \
     && apt-get -y install libcusparselt0 libcusparselt-dev \
     && rm cuda-keyring_1.1-1_all.deb \
+    && pip install numpy==1.23.5 \
     && rm -rf /var/lib/apt/lists/* \
     && echo "Ultralytics and dependencies successfully installed using JetPack 6.0 compatible wheels."
 


### PR DESCRIPTION
## Summary

This PR cleans up `docker/Dockerfile.orin` by reducing redundant installs, consolidating dependency layers, and making dev/debug tooling easier to exclude.

## Changes

- removed ROS packages from `reseq-base` that are already declared in the workspace `package.xml` files and can be resolved by `rosdep` in the final stage
- consolidated scattered Python installs into fewer layers
- removed the duplicate `numpy==1.23.5` installation
- separated optional debug/visualization tools behind `INSTALL_DEV_TOOLS=true`
- added missing `rm -rf /var/lib/apt/lists/*` cleanup to apt install blocks
- updated the Dockerfile header comments to reflect the current build path and stage layout

## Notes

The Dockerfile now keeps `reseq-base` focused on image-specific extras, while workspace-declared ROS dependencies are left to `rosdep install --from-path src` in the final `reseq` stage.

A slimmer build can now be produced with:

```bash
docker build -t reseq-orin -f docker/Dockerfile.orin --build-arg INSTALL_DEV_TOOLS=false .
