### PR TITLE
Implement lifting control in scaler and update CAN mappings for #112

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ __pycache__/
 
 build/
 install/
+
 log/
+.DS_Store

--- a/reseq_description/description/control/control_macros.xacro
+++ b/reseq_description/description/control/control_macros.xacro
@@ -33,12 +33,17 @@
         <joint name="mod${id}__roll_joint">
             <state_interface name="position" />
         </joint>
+
         <joint name="mod${id}__pitch_joint">
             <state_interface name="position" />
+            <command_interface name="position" />
+            <state_interface name="velocity" />
         </joint>
+
         <joint name="mod${id}__yaw_joint">
             <state_interface name="position" />
         </joint>
 
     </xacro:macro>
+
 </robot>

--- a/reseq_hardware/config/mappings.yaml
+++ b/reseq_hardware/config/mappings.yaml
@@ -164,3 +164,12 @@
     { name: "wrist_roll_arm_joint", mode: "velocity", },
   ]
 }
+- {
+  msg_id: 0x61,
+  modules: "skip_first",
+  length: 4,
+  is_command: true,
+  fields: [
+    { name: "pitch_joint", type: "command", mode: "position", }
+  ]
+}

--- a/reseq_ros2/reseq_ros2/scaler.py
+++ b/reseq_ros2/reseq_ros2/scaler.py
@@ -106,6 +106,8 @@ class Scaler(Node):
 
         self.speed_pub = self.create_publisher(Twist, '/cmd_vel', 10)
 
+        self.lift_pub = self.create_publisher(Vector3, '/inter_module_lift_vel', 10)
+
         self.get_logger().info('Scaler node started')
 
     def handle_buttons(self, buttons: list[bool]):
@@ -135,12 +137,32 @@ class Scaler(Node):
 
         # TODO probably to merge with another version of scaler.py
 
-        self.moveit_pub.publish(Vector3(
-            x = data.left.x,
-            y = data.left.y,
-            z = data.left.z,
-        ))
+        self.moveit_pub.publish(
+            Vector3(
+                x=data.left.x,
+                y=data.left.y,
+                z=data.left.z,
+            )
+        )
 
+        # LIFTING CONTROL: S2, S3, S4 Switches + Right Joystick Z axis
+        s2 = data.buttons[self.buttons_enum.S2]
+        s3 = data.buttons[self.buttons_enum.S3]
+        s4 = data.buttons[self.buttons_enum.S4]
+
+        if s2 or s3 or s4:
+            lift_msg = Vector3()
+            lift_msg.x = data.right.z  # Pitch set via right.z
+
+            if s2:
+                lift_msg.z = 1.0
+            elif s3:
+                lift_msg.z = 2.0
+            elif s4:
+                lift_msg.z = 3.0
+
+            self.lift_pub.publish(lift_msg)
+            self.get_logger().info(f'Lifting module {lift_msg.z} with pitch {lift_msg.x}')
 
         if self.control_mode == Scaler.control_mode_enum.AGEVAR:
             cmd_vel = self.agevarScaler(cmd_vel)

--- a/reseq_ros2/reseq_ros2/scaler.py
+++ b/reseq_ros2/reseq_ros2/scaler.py
@@ -152,17 +152,23 @@ class Scaler(Node):
 
         if s2 or s3 or s4:
             lift_msg = Vector3()
-            lift_msg.x = data.right.z  # Pitch set via right.z
+            lift_msg.x = data.right.z  # Pitch of the lifting module
+            lift_msg.y = 0.0
 
             if s2:
                 lift_msg.z = 1.0
-            elif s3:
-                lift_msg.z = 2.0
-            elif s4:
-                lift_msg.z = 3.0
+                self.lift_pub.publish(lift_msg)
+                self.get_logger().info(f'Lifting module {lift_msg.z} with pitch {lift_msg.x}')
 
-            self.lift_pub.publish(lift_msg)
-            self.get_logger().info(f'Lifting module {lift_msg.z} with pitch {lift_msg.x}')
+            if s3:
+                lift_msg.z = 2.0
+                self.lift_pub.publish(lift_msg)
+                self.get_logger().info(f'Lifting module {lift_msg.z} with pitch {lift_msg.x}')
+
+            if s4:
+                lift_msg.z = 3.0
+                self.lift_pub.publish(lift_msg)
+                self.get_logger().info(f'Lifting module {lift_msg.z} with pitch {lift_msg.x}')
 
         if self.control_mode == Scaler.control_mode_enum.AGEVAR:
             cmd_vel = self.agevarScaler(cmd_vel)


### PR DESCRIPTION
Implemented lifting control logic in scaler.py.

Added CAN message mapping (0x61) for inter-module pitch joints in mappings.yaml.

Verified the logic via topic redirection using simulated remote messages in Docker.

Addresses #112.