### PR TITLE
Fix MK2 sim app control after auto-nav rebase

### DIFF
--- a/docker/Dockerfile.dtwin
+++ b/docker/Dockerfile.dtwin
@@ -56,6 +56,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-jazzy-forward-command-controller \
     ros-jazzy-joint-state-broadcaster \
     ros-jazzy-imu-sensor-broadcaster \
+    ros-jazzy-python-orocos-kdl-vendor \
     ros-jazzy-robot-state-publisher \
     ros-jazzy-velocity-controllers \
     ros-jazzy-xacro \

--- a/reseq_arm_mk2/CMakeLists.txt
+++ b/reseq_arm_mk2/CMakeLists.txt
@@ -11,6 +11,7 @@ foreach(dir config launch meshes urdf viz)
 endforeach(dir)
 
 ament_python_install_package(${PROJECT_NAME})
+ament_python_install_package(kdl_parser_py)
 
 install(PROGRAMS
   # "reseq_arm_mk2/coordinate_controller.py"

--- a/reseq_arm_mk2/CMakeLists.txt
+++ b/reseq_arm_mk2/CMakeLists.txt
@@ -14,7 +14,8 @@ ament_python_install_package(${PROJECT_NAME})
 ament_python_install_package(kdl_parser_py)
 
 install(PROGRAMS
-  # "reseq_arm_mk2/coordinate_controller.py"
+  "reseq_arm_mk2/cartesian_arm_controller.py"
+  "reseq_arm_mk2/coordinate_controller.py"
   "reseq_arm_mk2/moveit_controller.py"
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/reseq_arm_mk2/kdl_parser_py/__init__.py
+++ b/reseq_arm_mk2/kdl_parser_py/__init__.py
@@ -1,0 +1,7 @@
+from . import urdf as _urdf
+
+treeFromFile = _urdf.treeFromFile
+treeFromString = _urdf.treeFromString
+treeFromUrdfModel = _urdf.treeFromUrdfModel
+
+__all__ = ['treeFromFile', 'treeFromString', 'treeFromUrdfModel']

--- a/reseq_arm_mk2/kdl_parser_py/urdf.py
+++ b/reseq_arm_mk2/kdl_parser_py/urdf.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import PyKDL as kdl
+except ImportError as exc:  # pragma: no cover - runtime dependency guard
+    raise ImportError(f'PyKDL import failed: {exc}') from exc
+
+
+@dataclass
+class _Origin:
+    xyz: list[float]
+    rpy: list[float]
+
+
+@dataclass
+class _Joint:
+    name: str
+    parent: str
+    child: str
+    joint_type: str
+    origin: _Origin
+    axis: list[float]
+
+
+@dataclass
+class _Link:
+    name: str
+    inertial: None = None
+
+
+class _URDFModel:
+    def __init__(self, root_link, joint_map, link_map, children_by_parent):
+        self._root_link = root_link
+        self.joint_map = joint_map
+        self.link_map = link_map
+        self._children_by_parent = children_by_parent
+
+    def get_root(self):
+        return self._root_link
+
+    def get_chain(self, root, tip, joints=True, links=False, fixed=True):
+        def _search(current_link, visited):
+            if current_link == tip:
+                return []
+
+            for joint_name in self._children_by_parent.get(current_link, []):
+                joint = self.joint_map[joint_name]
+                if joint.child in visited:
+                    continue
+                path = _search(joint.child, visited | {joint.child})
+                if path is not None:
+                    return [joint_name] + path
+            return None
+
+        path = _search(root, {root})
+        if path is None:
+            return []
+
+        if joints:
+            return path
+        if links:
+            links_path = [root]
+            for joint_name in path:
+                links_path.append(self.joint_map[joint_name].child)
+            return links_path
+        return []
+
+
+def _to_vector(values):
+    return kdl.Vector(values[0], values[1], values[2])
+
+
+def _to_rotation(values):
+    return kdl.Rotation.RPY(values[0], values[1], values[2])
+
+
+def _to_frame(origin):
+    return kdl.Frame(_to_rotation(origin.rpy), _to_vector(origin.xyz))
+
+
+def _joint_to_kdl(joint):
+    parent_frame = _to_frame(joint.origin)
+    axis = _to_vector(joint.axis)
+
+    if joint.joint_type in ('revolute', 'continuous'):
+        return kdl.Joint(joint.name, parent_frame.p, parent_frame.M * axis, kdl.Joint.RotAxis)
+    if joint.joint_type == 'prismatic':
+        return kdl.Joint(joint.name, parent_frame.p, parent_frame.M * axis, kdl.Joint.TransAxis)
+
+    return kdl.Joint(joint.name, kdl.Joint.Fixed)
+
+
+def _segment_from_joint_and_link(joint, link):
+    return kdl.Segment(link.name, _joint_to_kdl(joint), _to_frame(joint.origin))
+
+
+def _parse_origin(element):
+    if element is None:
+        return _Origin([0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
+
+    xyz = [0.0, 0.0, 0.0]
+    rpy = [0.0, 0.0, 0.0]
+    if element.get('xyz'):
+        xyz = [float(value) for value in element.get('xyz').split()]
+    if element.get('rpy'):
+        rpy = [float(value) for value in element.get('rpy').split()]
+    return _Origin(xyz, rpy)
+
+
+def _parse_axis(element):
+    if element is None or not element.get('xyz'):
+        return [0.0, 0.0, 0.0]
+    return [float(value) for value in element.get('xyz').split()]
+
+
+def _parse_urdf(xml_text):
+    root = ET.fromstring(xml_text)
+
+    links = {}
+    joint_map = {}
+    children_by_parent = {}
+    child_links = set()
+
+    for link_el in root.findall('link'):
+        name = link_el.get('name')
+        if not name:
+            continue
+        links[name] = _Link(name=name)
+
+    for joint_el in root.findall('joint'):
+        name = joint_el.get('name')
+        parent_el = joint_el.find('parent')
+        child_el = joint_el.find('child')
+        if not name or parent_el is None or child_el is None:
+            continue
+        parent = parent_el.get('link')
+        child = child_el.get('link')
+        if not parent or not child:
+            continue
+
+        joint = _Joint(
+            name=name,
+            parent=parent,
+            child=child,
+            joint_type=joint_el.get('type', 'fixed'),
+            origin=_parse_origin(joint_el.find('origin')),
+            axis=_parse_axis(joint_el.find('axis')),
+        )
+        joint_map[name] = joint
+        children_by_parent.setdefault(parent, []).append(name)
+        child_links.add(child)
+
+    root_links = [name for name in links if name not in child_links]
+    root_link = root_links[0] if root_links else None
+    if root_link is None:
+        return None
+
+    return _URDFModel(root_link, joint_map, links, children_by_parent)
+
+
+class _TreeShim:
+    def __init__(self, robot_model):
+        self._robot_model = robot_model
+
+    def getChain(self, root, tip, chain):
+        joint_names = self._robot_model.get_chain(root, tip, joints=True, links=False, fixed=True)
+        if not joint_names:
+            return False
+
+        for joint_name in joint_names:
+            joint = self._robot_model.joint_map[joint_name]
+            child_link = self._robot_model.link_map[joint.child]
+            chain.addSegment(_segment_from_joint_and_link(joint, child_link))
+
+        return True
+
+
+def treeFromUrdfModel(robot_model, tree=None):
+    root_name = robot_model.get_root()
+    if not root_name:
+        return False, None
+
+    return True, _TreeShim(robot_model)
+
+
+def treeFromString(xml, tree=None):
+    try:
+        robot_model = _parse_urdf(xml)
+    except Exception:
+        return False, None
+
+    if robot_model is None:
+        return False, None
+
+    return treeFromUrdfModel(robot_model, tree)
+
+
+def treeFromFile(file_path, tree=None):
+    xml = Path(file_path).read_text(encoding='utf-8')
+    return treeFromString(xml, tree)

--- a/reseq_arm_mk2/package.xml
+++ b/reseq_arm_mk2/package.xml
@@ -21,6 +21,7 @@ for the RESE.Q MK2 Manipulator</p>
   <exec_depend>moveit_configs_utils</exec_depend>
   <exec_depend>moveit_kinematics</exec_depend>
   <exec_depend>pick_ik</exec_depend>
+  <exec_depend>python_orocos_kdl_vendor</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
+++ b/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
@@ -1,0 +1,1138 @@
+#!/usr/bin/env python3
+"""
+Cartesian arm controller for the RESE.Q MK2 arm.
+
+It reads joint states, turns Cartesian velocity commands into joint motion
+with a damped Jacobian solve, and publishes the result to the arm
+controller. It also exposes a few small services for homing and mode
+switching.
+"""
+
+import traceback
+import xml.etree.ElementTree as ET
+
+import numpy as np
+import rclpy
+from geometry_msgs.msg import Vector3
+from rclpy.duration import Duration
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Float64MultiArray
+from std_srvs.srv import SetBool, Trigger
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+
+# Try to use KDL when it is available.
+_HAS_KDL = False
+_KDL_ERR = 'not attempted'
+try:
+    import PyKDL as kdl
+except ImportError as _e:
+    _KDL_ERR = f'PyKDL import failed: {_e}'
+else:
+    try:
+        from kdl_parser_py.urdf import treeFromString
+    except ImportError as _e:
+        _KDL_ERR = f'kdl_parser_py import failed: {_e}'
+    else:
+        _HAS_KDL = True
+
+
+def _clamp_joint_velocity_to_limits(
+    current_q: np.ndarray,
+    dq: np.ndarray,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+    dt: float,
+) -> np.ndarray:
+    """Clamp per-joint velocity so the next step cannot cross hard limits."""
+    dq_limited = np.array(dq, dtype=float, copy=True)
+    for i in range(len(dq_limited)):
+        if dq_limited[i] > 0.0:
+            remaining = max(0.0, q_hi[i] - current_q[i])
+            dq_limited[i] = min(dq_limited[i], remaining / dt)
+        elif dq_limited[i] < 0.0:
+            remaining = max(0.0, current_q[i] - q_lo[i])
+            dq_limited[i] = max(dq_limited[i], -remaining / dt)
+    return dq_limited
+
+
+def _compute_joint_hold_velocity(
+    current_q: np.ndarray,
+    target_q: np.ndarray,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+    dt: float,
+    gain: float,
+    max_joint_vel: float,
+    tolerance: float,
+) -> np.ndarray:
+    """Proportional pose hold in joint-velocity space around a target pose."""
+    error = target_q - current_q
+    dq = gain * error
+    dq[np.abs(error) <= tolerance] = 0.0
+    dq = np.clip(dq, -max_joint_vel, max_joint_vel)
+    return _clamp_joint_velocity_to_limits(current_q, dq, q_lo, q_hi, dt)
+
+
+def _idle_hold_command(
+    current_q: np.ndarray,
+    hold_target: np.ndarray,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+    dt: float,
+    gain: float,
+    max_joint_vel: float,
+    tolerance: float,
+    hold_armed: bool,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return the idle hold target and velocity command.
+
+    Before the operator has moved the arm, a captured startup pose is only an
+    observation. On real hardware the first joint state can briefly contain the
+    hardware interface's zero-initialized buffers, so an unarmed hold must never
+    drive back toward that value.
+    """
+    if not hold_armed:
+        passive_target = np.array(current_q, dtype=float, copy=True)
+        return passive_target, np.zeros_like(current_q)
+
+    target = np.array(hold_target, dtype=float, copy=True)
+    dq = _compute_joint_hold_velocity(
+        current_q=current_q,
+        target_q=target,
+        q_lo=q_lo,
+        q_hi=q_hi,
+        dt=dt,
+        gain=gain,
+        max_joint_vel=max_joint_vel,
+        tolerance=tolerance,
+    )
+    return target, dq
+
+
+def _advance_velocity_hold_target(
+    current_q: np.ndarray,
+    dq: np.ndarray,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+    dt: float,
+) -> np.ndarray:
+    """Keep the velocity-mode hold target near the measured arm state.
+
+    In velocity mode the robot only receives `dq`, not a future joint position
+    target. Advancing the internal hold target by a long trajectory horizon
+    makes the arm chase a phantom pose when the operator releases the stick.
+    """
+    return np.clip(current_q + dq * dt, q_lo, q_hi)
+
+
+def _startup_recovery_command(
+    current_q: np.ndarray,
+    target_q: np.ndarray,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+    dt: float,
+    gain: float,
+    max_joint_vel: float,
+    tolerance: float,
+) -> tuple[np.ndarray, bool]:
+    """Return the startup hold velocity and whether the target pose is reached."""
+    max_error = float(np.max(np.abs(target_q - current_q)))
+    if max_error <= tolerance:
+        return np.zeros_like(current_q), True
+    dq = _compute_joint_hold_velocity(
+        current_q=current_q,
+        target_q=target_q,
+        q_lo=q_lo,
+        q_hi=q_hi,
+        dt=dt,
+        gain=gain,
+        max_joint_vel=max_joint_vel,
+        tolerance=tolerance,
+    )
+    return dq, False
+
+
+def _unwrap_joint_positions(
+    current_q: np.ndarray,
+    reference_q: np.ndarray,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+) -> np.ndarray:
+    """Keep periodic joints continuous by unwrapping them against a reference pose."""
+    unwrapped_q = np.array(current_q, dtype=float, copy=True)
+    periodic_mask = (q_hi - q_lo) >= (2.0 * np.pi - 0.05)
+    if not np.any(periodic_mask):
+        return unwrapped_q
+
+    delta = unwrapped_q[periodic_mask] - reference_q[periodic_mask]
+    unwrapped_q[periodic_mask] = (
+        reference_q[periodic_mask] + ((delta + np.pi) % (2.0 * np.pi)) - np.pi
+    )
+    return unwrapped_q
+
+
+def _solve_weighted_dls_task_velocity(
+    task_jacobian: np.ndarray,
+    cart_vel: np.ndarray,
+    joint_weights: np.ndarray,
+    damping: float,
+) -> np.ndarray:
+    """Solve the weighted damped least-squares task velocity for the active joints."""
+    inv_joint_weights = np.diag(1.0 / joint_weights)
+    jj_t = task_jacobian @ inv_joint_weights @ task_jacobian.T
+    return (
+        inv_joint_weights
+        @ task_jacobian.T
+        @ np.linalg.solve(
+            jj_t + damping**2 * np.eye(task_jacobian.shape[0]),
+            cart_vel,
+        )
+    )
+
+
+def _solve_task_velocity_with_limit_redistribution(
+    current_q: np.ndarray,
+    task_jacobian: np.ndarray,
+    cart_vel: np.ndarray,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+    dt: float,
+    max_joint_vel: float,
+    damping: float,
+    joint_weights: np.ndarray,
+) -> tuple[np.ndarray, list[str], float]:
+    """Solve a task velocity and re-run it when a joint clips against a limit.
+
+    If one joint saturates, remove it from the current solve and let the remaining
+    joints redistribute the same Cartesian request instead of freezing the whole arm.
+    """
+    n_joints = task_jacobian.shape[1]
+    active = np.ones(n_joints, dtype=bool)
+    clipped_joints: list[str] = []
+    dq_final = np.zeros(n_joints)
+    vel_scale = 1.0
+
+    for _ in range(n_joints):
+        active_indices = np.flatnonzero(active)
+        if active_indices.size == 0:
+            break
+
+        active_jacobian = task_jacobian[:, active_indices]
+        active_weights = np.array(joint_weights[active_indices], dtype=float)
+        dq_active = _solve_weighted_dls_task_velocity(
+            task_jacobian=active_jacobian,
+            cart_vel=cart_vel,
+            joint_weights=active_weights,
+            damping=damping,
+        )
+
+        dq_candidate = np.zeros(n_joints)
+        dq_candidate[active_indices] = dq_active
+        dq_candidate += _joint_limit_recovery_velocity(
+            current_q=current_q,
+            q_lo=q_lo,
+            q_hi=q_hi,
+            max_joint_vel=max_joint_vel,
+        )
+
+        peak = float(np.max(np.abs(dq_active)))
+        vel_scale = 1.0
+        if peak > max_joint_vel:
+            vel_scale = max_joint_vel / peak
+            dq_candidate[active_indices] *= vel_scale
+
+        dq_clamped = _clamp_joint_velocity_to_limits(current_q, dq_candidate, q_lo, q_hi, dt)
+        clipped_indices = []
+        for idx in active_indices:
+            if dq_candidate[idx] > 0.0 and dq_clamped[idx] < dq_candidate[idx]:
+                clipped_indices.append(idx)
+            elif dq_candidate[idx] < 0.0 and dq_clamped[idx] > dq_candidate[idx]:
+                clipped_indices.append(idx)
+
+        dq_final = dq_clamped
+        if not clipped_indices:
+            return dq_final, clipped_joints, vel_scale
+
+        for idx in clipped_indices:
+            active[idx] = False
+            clipped_joints.append(f'J{idx}{"↑" if dq_candidate[idx] > 0.0 else "↓"}')
+
+    return dq_final, clipped_joints, vel_scale
+
+
+def _joint_limit_hold_scale(
+    current_q: np.ndarray,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+    margin_ratio: float = 0.15,
+) -> float:
+    """Fade the idle z hold as any joint approaches its hard limit."""
+    span = np.maximum(q_hi - q_lo, 1e-6)
+    limit_margin = np.maximum(span * margin_ratio, 1e-6)
+    distance_to_limit = np.minimum(current_q - q_lo, q_hi - current_q)
+    normalized_distance = np.clip(distance_to_limit / limit_margin, 0.0, 1.0)
+    hold_scale = float(np.min(normalized_distance))
+    return hold_scale * hold_scale
+
+
+def _joint_limit_recovery_velocity(
+    current_q: np.ndarray,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+    max_joint_vel: float,
+    margin_ratio: float = 0.2,
+    recovery_gain: float = 0.25,
+) -> np.ndarray:
+    """Nudge joints back toward the interior when the arm is near a hard stop."""
+    span = np.maximum(q_hi - q_lo, 1e-6)
+    limit_margin = np.maximum(span * margin_ratio, 1e-6)
+    distance_to_limit = np.minimum(current_q - q_lo, q_hi - current_q)
+    proximity = np.clip((limit_margin - distance_to_limit) / limit_margin, 0.0, 1.0)
+    if not np.any(proximity):
+        return np.zeros_like(current_q)
+
+    center = 0.5 * (q_lo + q_hi)
+    recovery = np.clip((center - current_q) / limit_margin, -1.0, 1.0)
+    recovery *= proximity * recovery_gain * max_joint_vel
+    return recovery
+
+
+class CartesianArmController(Node):
+    """
+    Jacobian-based Cartesian arm controller.
+
+    Subscribed Topics
+    -----------------
+    /mk2_arm_vel          geometry_msgs/Vector3   joystick input  [-1, 1]
+    /arm_joint_states     sensor_msgs/JointState
+
+    Published Topics
+    ----------------
+    /mk2_arm_controller/joint_trajectory          trajectory_msgs/JointTrajectory
+    /joint_group_velocity_controller/commands     std_msgs/Float64MultiArray
+
+    Services
+    --------
+    /cartesian_arm_controller/go_home       std_srvs/Trigger
+    /cartesian_arm_controller/switch_vel    std_srvs/SetBool  True=linear False=angular
+    /cartesian_arm_controller/set_mode      std_srvs/SetBool  True=velocity False=pos-incr
+
+    Parameters
+    ----------
+    robot_description      str    URDF XML (forwarded from robot_state_publisher)
+    chain_root             str    'arm_base_link'
+    chain_tip              str    'tool0'
+    command_frame          str    'arm_base_link'
+    velocity_topic         str    '/mk2_arm_vel'
+    state_topic            str    '/arm_joint_states'
+    trajectory_topic       str    '/mk2_arm_controller/joint_trajectory'
+    control_rate           float  33.0   Hz
+    max_cartesian_vel      float  0.3    m/s  (joystick [-1,1] scaled by this)
+    max_joint_vel          float  1.0    rad/s per joint
+    home_duration_sec      float  3.0    s
+    trajectory_horizon_sec float  0.10   s
+    command_mode           str    'trajectory' or 'velocity'
+    deadzone               float  0.02
+    jacobian_damping       float  0.05   damped-LS regularisation λ
+    joint_weights          float[]  joint weighting for the IK solve
+    """
+
+    # Joint order used everywhere in this controller.
+
+    JOINT_NAMES = [
+        'mod1__base_pitch_arm_joint',  # J0 shoulder pitch  (differential pair)
+        'mod1__base_roll_arm_joint',  # J1 shoulder roll   (differential pair)
+        'mod1__elbow_pitch_arm_joint',  # J2 elbow pitch
+        'mod1__forearm_roll_arm_joint',  # J3 forearm roll
+        'mod1__wrist_pitch_arm_joint',  # J4 wrist pitch
+        'mod1__wrist_roll_arm_joint',  # J5 wrist roll
+    ]
+    N_JOINTS = len(JOINT_NAMES)
+
+    # Fallback home pose used until the startup pose is captured from joint states.
+    HOME_POSITION = [0.8, 0.0, 0.8, 0.0, 0.0, 0.0]
+    HOME_TOLERANCE = 0.03
+    JOINT_WEIGHTS = np.ones(6, dtype=float)
+
+    # Defaults – _parse_urdf_limits() replaces these from the actual URDF.
+    _LOWER_DEFAULT = np.array([-0.10, -3.14, -0.10, -3.14, -0.46, -3.14])
+    _UPPER_DEFAULT = np.array([2.80, 3.14, 2.88, 3.14, 1.57, 3.14])
+
+    def __init__(self):
+        super().__init__('cartesian_arm_controller')
+
+        # Parameters we expect from the launch file.
+        self.declare_parameter('robot_description', '')
+        self.declare_parameter('chain_root', 'arm_base_link')
+        self.declare_parameter('chain_tip', 'tool0')
+        self.declare_parameter('command_frame', 'arm_base_link')
+        self.declare_parameter('velocity_topic', '/mk2_arm_vel')
+        self.declare_parameter('state_topic', '/arm_joint_states')
+        self.declare_parameter('trajectory_topic', '/mk2_arm_controller/joint_trajectory')
+        self.declare_parameter('control_rate', 33.0)
+        self.declare_parameter('max_cartesian_vel', 0.6)
+        self.declare_parameter('max_joint_vel', 0.5)
+        self.declare_parameter('home_duration_sec', 3.0)
+        self.declare_parameter('trajectory_horizon_sec', 0.10)
+        self.declare_parameter('command_mode', 'trajectory')
+        self.declare_parameter('startup_hold_positions', [float('nan')] * self.N_JOINTS)
+        self.declare_parameter('deadzone', 0.02)
+        self.declare_parameter('jacobian_damping', 0.05)
+        self.declare_parameter('joint_weights', self.JOINT_WEIGHTS.tolist())
+        self.declare_parameter('idle_hold_gain', 1.5)
+        self.declare_parameter('idle_hold_tolerance', 0.01)
+        self.declare_parameter('front_branch_gain', 0.05)
+
+        # Internal state.
+        self._q: np.ndarray | None = None  # measured joint positions
+        self._q_continuous: np.ndarray | None = None  # unwraps periodic joints across ±pi
+        self._q_cmd: np.ndarray | None = None  # integrator state
+        self._cmd_vel = np.zeros(3)  # latest joystick command
+        self._linear_mode = True
+        self._velocity_mode = True
+        self._moving = False
+        self._ee_z_ref: float | None = None
+        self._front_x_ref: float | None = None
+        self._front_branch_gain = (
+            self.get_parameter('front_branch_gain').get_parameter_value().double_value
+        )
+        self._diag_ctr = 0
+        self._home_active = False
+        self._startup_home: np.ndarray | None = None
+        self._startup_measured_pose: np.ndarray | None = None
+        self._startup_hold_sent = False
+        self._startup_hold_complete = False
+        self._startup_recovery_active = False
+        self._startup_recovery_logged = False
+        startup_hold_positions = list(self.get_parameter('startup_hold_positions').value)
+        self._startup_hold_target = None
+        if len(startup_hold_positions) == self.N_JOINTS:
+            startup_hold_array = np.array(startup_hold_positions, dtype=float)
+            if np.isfinite(startup_hold_array).any():
+                self._startup_hold_target = startup_hold_array
+        if self._startup_hold_target is None:
+            self._startup_hold_complete = True
+        self._idle_hold_armed = self._startup_hold_target is not None
+
+        joint_weights_param = self.get_parameter('joint_weights').value
+        if isinstance(joint_weights_param, (list, tuple, np.ndarray)) and (
+            len(joint_weights_param) == self.N_JOINTS
+        ):
+            self._joint_weights = np.array(joint_weights_param, dtype=float)
+        else:
+            self._joint_weights = self.JOINT_WEIGHTS.copy()
+
+        # Joint limits, replaced later with values from the URDF.
+        self._q_lo = self._LOWER_DEFAULT.copy()
+        self._q_hi = self._UPPER_DEFAULT.copy()
+
+        # KDL setup.
+        self._kdl_chain = None
+        self._fk_solver = None
+        self._jac_solver = None
+        self._chain_root = self.get_parameter('chain_root').get_parameter_value().string_value
+        self._chain_tip = self.get_parameter('chain_tip').get_parameter_value().string_value
+        self._load_kdl()
+
+        self._command_frame = (
+            self.get_parameter('command_frame').get_parameter_value().string_value
+        )
+        self._command_mode = self.get_parameter('command_mode').get_parameter_value().string_value
+        velocity_topic = self.get_parameter('velocity_topic').get_parameter_value().string_value
+        state_topic = self.get_parameter('state_topic').get_parameter_value().string_value
+
+        # ROS interfaces.
+        self.create_subscription(Vector3, velocity_topic, self._cb_vel, 10)
+        self.create_subscription(JointState, state_topic, self._cb_joint_state, 10)
+
+        traj_topic = self.get_parameter('trajectory_topic').get_parameter_value().string_value
+        self._traj_pub = self.create_publisher(JointTrajectory, traj_topic, 10)
+        self._vel_pub = self.create_publisher(
+            Float64MultiArray, '/joint_group_velocity_controller/commands', 10
+        )
+        self._vel_pub_legacy = self.create_publisher(
+            Float64MultiArray, '/joint_group_velocity_controller/command', 10
+        )
+
+        self.create_service(Trigger, '/cartesian_arm_controller/go_home', self._srv_home)
+        self.create_service(SetBool, '/cartesian_arm_controller/switch_vel', self._srv_switch_vel)
+        self.create_service(SetBool, '/cartesian_arm_controller/set_mode', self._srv_set_mode)
+
+        rate = self.get_parameter('control_rate').get_parameter_value().double_value
+        self._dt = 1.0 / rate
+        self._timer = self.create_timer(self._dt, self._control_loop)
+
+        kdl_status = 'YES' if self._kdl_chain else 'NO – numerical fallback'
+        self.get_logger().info(
+            f'CartesianArmController ready | KDL={kdl_status} | '
+            f'frame={self._command_frame} | mode={self._command_mode} | '
+            f'home={self.HOME_POSITION}'
+        )
+
+    # KDL setup.
+
+    def _load_kdl(self):
+        if not _HAS_KDL:
+            self.get_logger().warn(
+                f'KDL unavailable ({_KDL_ERR}). '
+                'Using numerical Jacobian – Y-axis direction may be wrong.'
+            )
+            return
+
+        urdf = self.get_parameter('robot_description').get_parameter_value().string_value
+        if not urdf:
+            self.get_logger().warn(
+                'robot_description is empty -> KDL disabled. '
+                'Pass robot_description parameter from the launch file.'
+            )
+            return
+
+        try:
+            ok, tree = treeFromString(urdf)
+        except Exception as e:
+            self.get_logger().error(f'treeFromString raised: {e}')
+            return
+
+        if not ok:
+            self.get_logger().error('treeFromString failed – URDF may be malformed.')
+            return
+
+        root = self._chain_root
+        tip = self._chain_tip
+        chain = kdl.Chain()
+        if not tree.getChain(root, tip, chain):
+            fallback_tip = 'tool0'
+            if tip != fallback_tip and tree.getChain(root, fallback_tip, chain):
+                self.get_logger().warn(
+                    f'KDL getChain({root} -> {tip}) failed; using {fallback_tip} instead.'
+                )
+                tip = fallback_tip
+                self._chain_tip = fallback_tip
+            else:
+                fallback_tip = 'arm_roll_wrist_link'
+                if tip != fallback_tip and tree.getChain(root, fallback_tip, chain):
+                    self.get_logger().warn(
+                        f'KDL getChain({root} -> {tip}) failed; using {fallback_tip} instead.'
+                    )
+                    tip = fallback_tip
+                    self._chain_tip = fallback_tip
+                else:
+                    self.get_logger().error(f'KDL getChain({root} -> {tip}) failed.')
+                    return
+
+        n = chain.getNrOfJoints()
+        if n != self.N_JOINTS:
+            self.get_logger().warn(
+                f'KDL chain has {n} joints, expected {self.N_JOINTS}. '
+                'Check chain_root/chain_tip parameters.'
+            )
+
+        self._kdl_chain = chain
+        self._fk_solver = kdl.ChainFkSolverPos_recursive(chain)
+        self._jac_solver = kdl.ChainJntToJacSolver(chain)
+        self._parse_urdf_limits(urdf)
+
+        # Startup diagnostics.
+        self.get_logger().info(
+            f'KDL chain {root}->{tip}: {n} joint(s)\n'
+            f'  lower: {np.round(self._q_lo, 3).tolist()}\n'
+            f'  upper: {np.round(self._q_hi, 3).tolist()}'
+        )
+
+        q_home = np.array(self.HOME_POSITION, dtype=float)
+        p_home = self._fk_kdl(q_home)
+        if p_home is not None:
+            self.get_logger().info(
+                f'FK(home) = [{p_home[0]:.4f}, {p_home[1]:.4f}, {p_home[2]:.4f}] m'
+            )
+            self._front_x_ref = float(p_home[0])
+
+        J_home = self._jacobian_kdl(q_home)
+        if J_home is not None:
+            rank = int(np.linalg.matrix_rank(J_home, tol=1e-3))
+            self.get_logger().info(
+                f'Jacobian at home position (3×{n}, rank={rank}):\n{np.round(J_home, 4)}'
+            )
+            if rank < 3:
+                self.get_logger().warn(
+                    f'Jacobian rank {rank} < 3 at home – arm is in a singular configuration! '
+                    'Some Cartesian directions will not be controllable from home.'
+                )
+
+    def _parse_urdf_limits(self, urdf: str):
+        """Read joint limits from the URDF."""
+        try:
+            root_el = ET.fromstring(urdf)
+            for jel in root_el.findall('joint'):
+                name = jel.get('name', '')
+                if name not in self.JOINT_NAMES:
+                    continue
+                idx = self.JOINT_NAMES.index(name)
+                lim = jel.find('limit')
+                if lim is None:
+                    continue
+                lo = lim.get('lower')
+                hi = lim.get('upper')
+                if lo is not None:
+                    self._q_lo[idx] = float(lo)
+                if hi is not None:
+                    self._q_hi[idx] = float(hi)
+        except Exception as e:
+            self.get_logger().warn(f'Could not parse URDF joint limits: {e}')
+
+    # ROS callbacks.
+
+    def _cb_joint_state(self, msg: JointState):
+        pos_map = dict(zip(msg.name, msg.position))
+        try:
+            self._q = np.array([pos_map[n] for n in self.JOINT_NAMES])
+            if self._q_continuous is None:
+                self._q_continuous = self._q.copy()
+            else:
+                self._q_continuous = _unwrap_joint_positions(
+                    current_q=self._q,
+                    reference_q=self._q_continuous,
+                    q_lo=self._q_lo,
+                    q_hi=self._q_hi,
+                )
+            if self._startup_home is None:
+                self._startup_measured_pose = self._q.copy()
+                hold_tolerance = (
+                    self.get_parameter('idle_hold_tolerance').get_parameter_value().double_value
+                )
+                if self._startup_hold_target is not None:
+                    self._startup_home = np.clip(self._startup_hold_target, self._q_lo, self._q_hi)
+                    startup_error = float(
+                        np.max(np.abs(self._startup_home - self._startup_measured_pose))
+                    )
+                    self._startup_recovery_active = startup_error > hold_tolerance
+                    self._startup_hold_complete = not self._startup_recovery_active
+                    self.get_logger().info(
+                        'Captured startup joint state: '
+                        f'measured={np.round(self._startup_measured_pose, 3).tolist()} '
+                        f'hold_target={np.round(self._startup_home, 3).tolist()}'
+                    )
+                else:
+                    self._startup_home = self._q.copy()
+                    self._startup_hold_complete = True
+                    self.get_logger().info(
+                        f'Captured startup home pose: {np.round(self._startup_home, 3).tolist()}'
+                    )
+            elif self._startup_hold_target is None and not self._idle_hold_armed:
+                self._startup_measured_pose = self._q.copy()
+                self._startup_home = self._q.copy()
+        except KeyError:
+            pass  # not all arm joints present yet
+
+    def _cb_vel(self, msg: Vector3):
+        self._cmd_vel = np.array([msg.x, msg.y, msg.z])
+
+    # Forward kinematics.
+
+    def _fk_kdl(self, q: np.ndarray) -> np.ndarray | None:
+        n = self._kdl_chain.getNrOfJoints()
+        q_kdl = kdl.JntArray(n)
+        for i in range(min(n, self.N_JOINTS)):
+            q_kdl[i] = float(q[i])
+        frame = kdl.Frame()
+        if self._fk_solver.JntToCart(q_kdl, frame) < 0:
+            return None
+        return np.array([frame.p.x(), frame.p.y(), frame.p.z()])
+
+    def _fk_frame_kdl(self, q: np.ndarray) -> kdl.Frame | None:
+        n = self._kdl_chain.getNrOfJoints()
+        q_kdl = kdl.JntArray(n)
+        for i in range(min(n, self.N_JOINTS)):
+            q_kdl[i] = float(q[i])
+
+        frame = kdl.Frame()
+        if self._fk_solver.JntToCart(q_kdl, frame) < 0:
+            return None
+        return frame
+
+    def _fk_numerical(self, q: np.ndarray) -> np.ndarray:
+        """
+        Simple FK fallback for cases where KDL is not available.
+
+        It uses joint origin translations from the URDF, so it is only an
+        approximation and will not capture the full joint orientation math.
+        """
+        # Approximate link lengths taken from the URDF joint origins.
+        L1, L2, L3 = 0.289, 0.170, 0.054
+        q0, q1, q2, _, q4, _ = q
+        az = q1  # azimuth (base_roll)
+        el0 = q0  # shoulder elevation
+        el2 = q0 + q2  # elbow elevation
+        el4 = q0 + q2 + q4
+        reach = L1 * np.cos(el0) + L2 * np.cos(el2) + L3 * np.cos(el4)
+        x = np.cos(az) * reach
+        y = np.sin(az) * reach
+        z = L1 * np.sin(el0) + L2 * np.sin(el2) + L3 * np.sin(el4)
+        return np.array([x, y, z])
+
+    def _get_ee_pos(self, q: np.ndarray) -> np.ndarray:
+        if self._fk_solver is not None:
+            r = self._fk_kdl(q)
+            if r is not None:
+                return r
+        return self._fk_numerical(q)
+
+    def _command_velocity_in_base(self, q: np.ndarray, cmd_vel: np.ndarray) -> np.ndarray:
+        command_frame = self._command_frame
+        if command_frame == self._chain_root:
+            return cmd_vel
+
+        if self._fk_solver is None:
+            self.get_logger().warn(
+                f'Cannot transform commands from {command_frame} without KDL; using base frame.',
+                throttle_duration_sec=5.0,
+            )
+            return cmd_vel
+
+        if command_frame != self._chain_tip:
+            self.get_logger().warn(
+                f'Unsupported command_frame {command_frame}; using base frame command.',
+                throttle_duration_sec=5.0,
+            )
+            return cmd_vel
+
+        frame = self._fk_frame_kdl(q)
+        if frame is None:
+            return cmd_vel
+
+        base_vec = frame.M * kdl.Vector(float(cmd_vel[0]), float(cmd_vel[1]), float(cmd_vel[2]))
+        return np.array([base_vec[0], base_vec[1], base_vec[2]])
+
+    # Jacobian.
+
+    def _jacobian_kdl(self, q: np.ndarray) -> np.ndarray | None:
+        """
+        Return the full 6D Jacobian via KDL.
+
+        Rows 0-2 are linear velocity and rows 3-5 are angular velocity.
+        The element-wise access is used because it works reliably across
+        PyKDL builds.
+        """
+        n = self._kdl_chain.getNrOfJoints()
+        q_kdl = kdl.JntArray(n)
+        for i in range(min(n, self.N_JOINTS)):
+            q_kdl[i] = float(q[i])
+
+        jac = kdl.Jacobian(n)
+        if self._jac_solver.JntToJac(q_kdl, jac) < 0:
+            self.get_logger().warn('KDL JntToJac error.')
+            return None
+
+        try:
+            J = np.array([[jac[r, c] for c in range(n)] for r in range(6)])
+        except Exception as e:
+            self.get_logger().warn(f'Jacobian extraction failed ({e}) – falling back.')
+            return None
+
+        return J
+
+    def _jacobian_numerical(self, q: np.ndarray, eps: float = 1e-4) -> np.ndarray:
+        p0 = self._fk_numerical(q)
+        J = np.zeros((6, self.N_JOINTS))
+        for i in range(self.N_JOINTS):
+            dq = q.copy()
+            dq[i] += eps
+            J[:3, i] = (self._fk_numerical(dq) - p0) / eps
+        return J
+
+    def _get_jacobian(self, q: np.ndarray) -> np.ndarray | None:
+        if self._jac_solver is not None:
+            return self._jacobian_kdl(q)
+        self.get_logger().warn(
+            'KDL not available – numerical Jacobian (Y-axis may be wrong!)',
+            throttle_duration_sec=5.0,
+        )
+        return self._jacobian_numerical(q)
+
+    # Main control loop (33 Hz).
+
+    def _control_loop(self):
+        if self._q is None:
+            return
+
+        # Initialize the integrator on the first valid joint state.
+        if self._q_cmd is None:
+            self._q_cmd = (
+                self._startup_home.copy() if self._startup_home is not None else self._q.copy()
+            )
+            self._moving = False
+
+        if self._command_mode == 'trajectory' and not self._startup_hold_sent:
+            if self._traj_pub.get_subscription_count() > 0:
+                startup_target = self._q_cmd.copy() if self._q_cmd is not None else self._q.copy()
+                self._q_cmd = startup_target.copy()
+                self._publish_traj(self._q.tolist(), startup_target.tolist(), 0.1)
+                self._startup_hold_sent = True
+
+        deadzone = self.get_parameter('deadzone').get_parameter_value().double_value
+        cmd_norm = float(np.linalg.norm(self._cmd_vel))
+        # Treat a perfectly centered stick as idle even when deadzone is configured to 0.0.
+        idle_threshold = max(deadzone, 1e-6)
+
+        if self._home_active:
+            self._run_home_velocity()
+            return
+
+        if self._startup_recovery_active:
+            if cmd_norm > idle_threshold:
+                current_q = self._q_continuous if self._q_continuous is not None else self._q
+                self._startup_recovery_active = False
+                self._startup_hold_complete = True
+                self._startup_recovery_logged = False
+                self._q_cmd = current_q.copy()
+                self.get_logger().info('Startup recovery interrupted by manual arm command.')
+            else:
+                self._run_startup_recovery()
+                return
+
+        # Ignore tiny inputs.
+        if cmd_norm <= idle_threshold:
+            if self._command_mode == 'velocity':
+                max_jv = self.get_parameter('max_joint_vel').get_parameter_value().double_value
+                hold_gain = self.get_parameter('idle_hold_gain').get_parameter_value().double_value
+                hold_tolerance = (
+                    self.get_parameter('idle_hold_tolerance').get_parameter_value().double_value
+                )
+                hold_target = self._q_cmd.copy() if self._q_cmd is not None else self._q.copy()
+                if not self._startup_hold_complete and self._startup_hold_target is not None:
+                    startup_target = np.clip(self._startup_hold_target, self._q_lo, self._q_hi)
+                    hold_target = startup_target
+                    if float(np.max(np.abs(startup_target - self._q))) <= hold_tolerance:
+                        self._startup_hold_complete = True
+                hold_target, hold_dq = _idle_hold_command(
+                    current_q=self._q,
+                    hold_target=hold_target,
+                    q_lo=self._q_lo,
+                    q_hi=self._q_hi,
+                    dt=self._dt,
+                    gain=hold_gain,
+                    max_joint_vel=max_jv,
+                    tolerance=hold_tolerance,
+                    hold_armed=self._idle_hold_armed,
+                )
+                self._q_cmd = hold_target.copy()
+                self._publish_velocity(hold_dq.tolist())
+            else:
+                # In trajectory mode the arm needs a steady hold target while idle.
+                # Without this, Gazebo can let the joints settle under gravity after
+                # the last short trajectory finishes, which shows up as a startup tilt.
+                hold_target = self._q_cmd.tolist() if self._q_cmd is not None else self._q.tolist()
+                self._publish_traj(self._q.tolist(), hold_target, 0.1)
+            self._moving = False
+            self._ee_z_ref = None
+            return
+
+        # Solve from the live measured pose so the Jacobian tracks the actual arm.
+        if not self._moving:
+            self._moving = True
+        self._idle_hold_armed = True
+        solve_q = self._q_continuous if self._q_continuous is not None else self._q
+        if self._ee_z_ref is None:
+            self._ee_z_ref = float(self._get_ee_pos(solve_q)[2])
+
+        if not self._linear_mode:
+            # Orientation mode is not implemented yet.
+            return
+
+        # Control parameters.
+        max_cv = self.get_parameter('max_cartesian_vel').get_parameter_value().double_value
+        max_jv = self.get_parameter('max_joint_vel').get_parameter_value().double_value
+        lam = self.get_parameter('jacobian_damping').get_parameter_value().double_value
+        horizon = self.get_parameter('trajectory_horizon_sec').get_parameter_value().double_value
+        horizon = max(horizon, self._dt * 2.0)  # never shorter than 2 control ticks
+
+        # Interpret the input in the configured command frame, then solve in base coordinates.
+        cart_vel_cmd = self._cmd_vel * max_cv
+        cart_vel = self._command_velocity_in_base(solve_q, cart_vel_cmd)
+
+        # Hold the current height unless the user is explicitly commanding Z.
+        # This keeps lateral motion from slowly climbing as the arm changes posture.
+        if self._ee_z_ref is not None and abs(cart_vel_cmd[2]) < deadzone:
+            z_error = self._ee_z_ref - float(self._get_ee_pos(solve_q)[2])
+            z_hold_vel = 2.0 * z_error
+            hold_scale = _joint_limit_hold_scale(solve_q, self._q_lo, self._q_hi)
+            # Relax the height hold near saturation so a reverse x/y command can
+            # back the arm away from the limit instead of fighting the stale z target.
+            cart_vel[2] = float(np.clip(z_hold_vel * hold_scale, -max_cv, max_cv))
+
+        if self._front_x_ref is not None and abs(cart_vel_cmd[0]) < deadzone:
+            x_error = self._front_x_ref - float(self._get_ee_pos(solve_q)[0])
+            if x_error > 0.0:
+                # Keep lateral motion on the front side of the workspace unless the
+                # operator is explicitly commanding X.
+                cart_vel[0] = float(np.clip(2.0 * x_error, 0.0, max_cv))
+
+        J = self._get_jacobian(solve_q)
+        if J is None:
+            return
+
+        # Damped least-squares IK on the tool translational task.
+        try:
+            active_dofs = J.shape[1]
+            Jlin = J[:3, :active_dofs]
+            joint_weights = self._joint_weights[:active_dofs]
+            dq, joints_clipped, vel_scale = _solve_task_velocity_with_limit_redistribution(
+                current_q=solve_q,
+                task_jacobian=Jlin,
+                cart_vel=cart_vel,
+                q_lo=self._q_lo,
+                q_hi=self._q_hi,
+                dt=self._dt,
+                max_joint_vel=max_jv,
+                damping=lam,
+                joint_weights=joint_weights,
+            )
+        except np.linalg.LinAlgError:
+            self.get_logger().warn('DLS solve failed.')
+            return
+
+        if (
+            self._startup_home is not None
+            and self._front_x_ref is not None
+            and abs(cart_vel_cmd[0]) < deadzone
+            and abs(cart_vel_cmd[1]) > deadzone
+            and self._front_branch_gain > 0.0
+        ):
+            # Bias the nullspace toward the startup/front branch while the user is
+            # steering y. This keeps reversals from flipping to the back side without
+            # injecting a sideways pull into pure vertical motion.
+            branch_bias = np.clip(
+                self._front_branch_gain * (self._startup_home - solve_q),
+                -0.25 * max_jv,
+                0.25 * max_jv,
+            )
+            dq = dq + branch_bias
+            dq = np.clip(dq, -max_jv, max_jv)
+            dq = _clamp_joint_velocity_to_limits(solve_q, dq, self._q_lo, self._q_hi, self._dt)
+
+        # In trajectory mode, generate the next target from the measured pose.
+        # This keeps the published joint step consistent with the Jacobian
+        # linearization and avoids accumulating backlog when hardware tracking
+        # lags behind the previously commanded target.
+        if self._command_mode == 'trajectory':
+            self._q_cmd = np.clip(solve_q + dq * horizon, self._q_lo, self._q_hi)
+        else:
+            # Velocity mode should hold near the actual arm pose, not a
+            # long-horizon prediction. Using the trajectory lookahead here
+            # causes a snap when manual input returns to zero.
+            self._q_cmd = _advance_velocity_hold_target(
+                current_q=solve_q,
+                dq=dq,
+                q_lo=self._q_lo,
+                q_hi=self._q_hi,
+                dt=self._dt,
+            )
+
+        # Print diagnostics at 1 Hz.
+        self._diag_ctr += 1
+        if self._diag_ctr % 33 == 0:
+            ee = self._get_ee_pos(self._q_cmd if self._q_cmd is not None else self._q)
+            achieved_cart = Jlin @ dq[:active_dofs]
+            self.get_logger().info(
+                f'cart_in={np.round(cart_vel, 3)} '
+                f'dq={np.round(dq, 3)} '
+                f'cart_out={np.round(achieved_cart, 3)} '
+                f'vel_scale={vel_scale:.2f} '
+                f'clipped={joints_clipped} '
+                f'vel_subs={self._vel_pub.get_subscription_count()} '
+                f'vel_legacy_subs={self._vel_pub_legacy.get_subscription_count()}\n'
+                f'  q_cmd={np.round(self._q_cmd, 3)}\n'
+                f'  q_meas={np.round(self._q, 3)}\n'
+                f'  EE={np.round(ee, 4)} m'
+            )
+
+        # Publish the command.
+        if self._command_mode == 'velocity':
+            self._publish_velocity(dq.tolist())
+        else:
+            self._publish_traj(self._q.tolist(), self._q_cmd.tolist(), horizon)
+
+    def _run_home_velocity(self):
+        """Drive the arm toward the configured home target in velocity mode."""
+        if self._q is None:
+            return
+
+        target = self._get_home_position()
+        self._q_cmd = target.copy()
+        current_q = self._q_continuous if self._q_continuous is not None else self._q
+        error = target - current_q
+
+        if float(np.max(np.abs(error))) < self.HOME_TOLERANCE:
+            self._home_active = False
+            self._moving = False
+            self._ee_z_ref = None
+            self._publish_velocity([0.0] * self.N_JOINTS)
+            self.get_logger().info('Home reached.')
+            return
+
+        max_jv = self.get_parameter('max_joint_vel').get_parameter_value().double_value
+        dur = self.get_parameter('home_duration_sec').get_parameter_value().double_value
+        home_gain = 1.0 / max(dur, self._dt)
+        dq = error * home_gain
+        dq = np.clip(dq, -max_jv, max_jv)
+
+        dq = _clamp_joint_velocity_to_limits(self._q, dq, self._q_lo, self._q_hi, self._dt)
+
+        self._publish_velocity(dq.tolist())
+
+    def _run_startup_recovery(self):
+        """Recover the arm to the configured startup hold pose before accepting manual motion."""
+        if self._q is None or self._startup_home is None:
+            return
+
+        max_jv = self.get_parameter('max_joint_vel').get_parameter_value().double_value
+        hold_gain = self.get_parameter('idle_hold_gain').get_parameter_value().double_value
+        hold_tolerance = (
+            self.get_parameter('idle_hold_tolerance').get_parameter_value().double_value
+        )
+        current_q = self._q_continuous if self._q_continuous is not None else self._q
+        dq, reached_target = _startup_recovery_command(
+            current_q=current_q,
+            target_q=self._startup_home,
+            q_lo=self._q_lo,
+            q_hi=self._q_hi,
+            dt=self._dt,
+            gain=hold_gain,
+            max_joint_vel=max_jv,
+            tolerance=hold_tolerance,
+        )
+
+        self._q_cmd = self._startup_home.copy()
+        self._moving = False
+        self._ee_z_ref = None
+
+        if not self._startup_recovery_logged:
+            self.get_logger().info(
+                'Startup recovery active: '
+                f'measured={np.round(self._q, 3).tolist()} '
+                f'target={np.round(self._startup_home, 3).tolist()}'
+            )
+            self._startup_recovery_logged = True
+
+        if reached_target:
+            self._startup_recovery_active = False
+            self._startup_hold_complete = True
+            self._startup_recovery_logged = False
+            self._publish_velocity([0.0] * self.N_JOINTS)
+            self.get_logger().info('Startup recovery complete.')
+            return
+
+        self._publish_velocity(dq.tolist())
+
+    def _get_home_position(self) -> np.ndarray:
+        if self._startup_home is not None:
+            return self._startup_home.copy()
+        return np.array(self.HOME_POSITION, dtype=float)
+
+    # Trajectory publisher.
+
+    def _publish_traj(
+        self, start_positions: list[float], target_positions: list[float], duration_sec: float
+    ):
+        """Publish a short two-point trajectory for the arm controller."""
+        traj = JointTrajectory()
+        traj.header.stamp.sec = 0  # execute immediately, preempt current
+        traj.header.stamp.nanosec = 0
+        traj.header.frame_id = self._command_frame
+        traj.joint_names = self.JOINT_NAMES
+
+        # Never send positions outside the joint limits.
+        start_safe = [
+            float(np.clip(start_positions[i], self._q_lo[i], self._q_hi[i]))
+            for i in range(self.N_JOINTS)
+        ]
+        target_safe = [
+            float(np.clip(target_positions[i], self._q_lo[i], self._q_hi[i]))
+            for i in range(self.N_JOINTS)
+        ]
+
+        pt_start = JointTrajectoryPoint()
+        pt_start.positions = start_safe
+        pt_start.velocities = [0.0] * self.N_JOINTS
+        pt_start.time_from_start = Duration(nanoseconds=0).to_msg()
+
+        pt_target = JointTrajectoryPoint()
+        pt_target.positions = target_safe
+        pt_target.velocities = [0.0] * self.N_JOINTS
+        pt_target.time_from_start = Duration(nanoseconds=int(duration_sec * 1e9)).to_msg()
+
+        traj.points = [pt_start, pt_target]
+        self._traj_pub.publish(traj)
+
+    def _publish_velocity(self, velocities: list[float]):
+        msg = Float64MultiArray()
+        msg.data = [float(v) for v in velocities]
+        self._vel_pub.publish(msg)
+        self._vel_pub_legacy.publish(msg)
+
+    # Services.
+
+    def _srv_home(self, _req: Trigger.Request, res: Trigger.Response) -> Trigger.Response:
+        dur = self.get_parameter('home_duration_sec').get_parameter_value().double_value
+        if self._q is None:
+            res.success = False
+            res.message = 'No joint state yet; cannot home arm'
+            self.get_logger().warn(res.message)
+            return res
+
+        home_target = self._get_home_position()
+        self._q_cmd = home_target.copy()
+        self._moving = True
+        self._idle_hold_armed = True
+        self._cmd_vel = np.zeros(3)
+        self._ee_z_ref = None
+        if self._command_mode == 'velocity':
+            self._home_active = True
+            res.success = True
+            res.message = f'Homing to {np.round(home_target, 3).tolist()} over {dur:.1f}s'
+        else:
+            self._home_active = False
+            start_positions = self._q.tolist() if self._q is not None else home_target.tolist()
+            self._publish_traj(start_positions, home_target.tolist(), dur)
+            res.success = True
+            res.message = f'Moving to home {np.round(home_target, 3).tolist()} over {dur:.1f}s'
+        self.get_logger().info(res.message)
+        return res
+
+    def _srv_switch_vel(self, req: SetBool.Request, res: SetBool.Response) -> SetBool.Response:
+        self._linear_mode = req.data
+        res.success = True
+        res.message = 'Velocity -> LINEAR' if req.data else 'Velocity -> ANGULAR'
+        self.get_logger().info(res.message)
+        return res
+
+    def _srv_set_mode(self, req: SetBool.Request, res: SetBool.Response) -> SetBool.Response:
+        self._command_mode = 'velocity' if req.data else 'trajectory'
+        res.success = True
+        res.message = 'Mode -> VELOCITY' if req.data else 'Mode -> POSITION INCREMENT'
+        self.get_logger().info(res.message)
+        return res
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    try:
+        node = CartesianArmController()
+        executor = MultiThreadedExecutor()
+        executor.add_node(node)
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    except Exception as err:
+        rclpy.logging.get_logger('cartesian_arm_controller').fatal(
+            f'Unhandled exception: {err}\n{traceback.format_exc()}'
+        )
+    finally:
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/reseq_description/config/mk1/scaler_consts.yaml
+++ b/reseq_description/config/mk1/scaler_consts.yaml
@@ -8,7 +8,10 @@ scaler_consts:
   r_angular_vel:             # [rad/s] Range of the angular velocity (pivot mode)
     - -2.8387
     - 2.8387
-  r_pitch_vel:               # [LSB/s] Range of pitch velocity
+  arm_vel_topic: /mk2_arm_vel_scaled # Scaler-only arm command topic consumed by the Cartesian controller
+  arm_input_scale: 1.0 # [-] Scale applied to left-stick arm commands before arm_vel_topic
+  arm_input_deadzone: 0.08 # [-] Deadzone applied to arm stick inputs before scaling
+  r_pitch_vel: # [LSB/s] Range of pitch velocity
     - -183
     - 183
   r_head_pitch_vel:          # [LSB/s] Range of indepepndent head pitch velocity

--- a/reseq_description/config/mk2/scaler_consts.yaml
+++ b/reseq_description/config/mk2/scaler_consts.yaml
@@ -8,3 +8,6 @@ scaler_consts:
   r_angular_vel:             # [rad/s] Range of the angular velocity (pivot mode)
     - -2.4912
     - 2.4912
+  arm_vel_topic: /mk2_arm_vel_scaled # Scaler-only arm command topic consumed by the Cartesian controller
+  arm_input_scale: 0.5 # [-] Scale applied to left-stick arm commands before arm_vel_topic
+  arm_input_deadzone: 0.08 # [-] Deadzone applied to arm stick inputs before scaling

--- a/reseq_ros2/config/slam_rviz.yaml
+++ b/reseq_ros2/config/slam_rviz.yaml
@@ -137,7 +137,7 @@ Visualization Manager:
       Color Transformer: RGB8
       Decay Time: 0
       Enabled: true
-      Name: RGBD Point Cloud
+      Name: Point Cloud Map
       Position Transformer: XYZ
       Size (m): 0.03
       Style: Points
@@ -146,7 +146,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /camera/depth/color/points
+        Value: /ply_map/points
       Value: true
     - Class: rviz_default_plugins/Image
       Enabled: true

--- a/reseq_ros2/launch/autonomy_launch.py
+++ b/reseq_ros2/launch/autonomy_launch.py
@@ -4,10 +4,13 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
+    ExecuteProcess,
     GroupAction,
     IncludeLaunchDescription,
     OpaqueFunction,
+    RegisterEventHandler,
 )
+from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node, SetRemap
@@ -16,6 +19,7 @@ from launch_ros.actions import Node, SetRemap
 def launch_setup(context, *args, **kwargs):
     nav2_share = get_package_share_directory('nav2_bringup')
     map_file = LaunchConfiguration('map_file').perform(context).strip()
+    wait_for_odom = LaunchConfiguration('wait_for_odom').perform(context).lower() == 'true'
 
     nav2_launch = GroupAction(
         actions=[
@@ -91,7 +95,30 @@ def launch_setup(context, *args, **kwargs):
             ]
         )
 
-    launch_actions.extend([nav2_launch, mux_node, explorer_node])
+    if wait_for_odom:
+        wait_for_odom_action = ExecuteProcess(
+            cmd=[
+                'zsh',
+                '-lc',
+                (
+                    'until ros2 topic info /diff_controller1/odom 2>/dev/null '
+                    '| grep -q "Publisher count: [1-9]"; do sleep 1; done'
+                ),
+            ],
+            output='screen',
+        )
+        launch_actions.extend(
+            [
+                wait_for_odom_action,
+                RegisterEventHandler(
+                    OnProcessExit(target_action=wait_for_odom_action, on_exit=[nav2_launch])
+                ),
+            ]
+        )
+    else:
+        launch_actions.append(nav2_launch)
+
+    launch_actions.extend([mux_node, explorer_node])
     return launch_actions
 
 
@@ -102,6 +129,11 @@ def generate_launch_description():
 
     use_sim_time_arg = DeclareLaunchArgument('use_sim_time', default_value='false')
     autostart_arg = DeclareLaunchArgument('autostart', default_value='true')
+    wait_for_odom_arg = DeclareLaunchArgument(
+        'wait_for_odom',
+        default_value='false',
+        description='Delay Nav2 startup until /diff_controller1/odom has a publisher',
+    )
     params_arg = DeclareLaunchArgument('nav2_params_file', default_value=default_nav2_params)
     autonomy_params_arg = DeclareLaunchArgument(
         'autonomy_params_file', default_value=default_autonomy_params
@@ -126,6 +158,7 @@ def generate_launch_description():
         [
             use_sim_time_arg,
             autostart_arg,
+            wait_for_odom_arg,
             params_arg,
             autonomy_params_arg,
             map_file_arg,

--- a/reseq_ros2/launch/autonomy_launch.py
+++ b/reseq_ros2/launch/autonomy_launch.py
@@ -98,7 +98,7 @@ def launch_setup(context, *args, **kwargs):
     if wait_for_odom:
         wait_for_odom_action = ExecuteProcess(
             cmd=[
-                'zsh',
+                'bash',
                 '-lc',
                 (
                     'until ros2 topic info /diff_controller1/odom 2>/dev/null '

--- a/reseq_ros2/launch/digital_twin_launch.py
+++ b/reseq_ros2/launch/digital_twin_launch.py
@@ -1,10 +1,16 @@
 import os
+import subprocess
 
 import xacro
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction, RegisterEventHandler
-from launch.event_handlers import OnProcessExit
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    OpaqueFunction,
+    RegisterEventHandler,
+)
+from launch.event_handlers import OnProcessExit, OnProcessStart
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
@@ -14,22 +20,93 @@ share_folder = get_package_share_directory('reseq_ros2')
 description_share_folder = get_package_share_directory('reseq_description')
 
 
+def _spawner(name: str, external_log_level: str, *extra_args: str) -> Node:
+    return Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=[
+            name,
+            '--controller-manager',
+            '/controller_manager',
+            '--controller-manager-timeout',
+            '60',
+            '--service-call-timeout',
+            '60',
+            *extra_args,
+            '--ros-args',
+            '--log-level',
+            external_log_level,
+        ],
+    )
+
+
+def _append_spawner_chain(launch_config, start_action, spawners):
+    if not spawners:
+        return
+
+    launch_config.append(
+        RegisterEventHandler(
+            OnProcessExit(
+                target_action=start_action,
+                on_exit=[spawners[0]],
+            )
+        )
+    )
+
+    for previous_spawner, next_spawner in zip(spawners, spawners[1:]):
+        launch_config.append(
+            RegisterEventHandler(
+                OnProcessExit(
+                    target_action=previous_spawner,
+                    on_exit=[next_spawner],
+                )
+            )
+        )
+
+
 # launch_setup is used through an OpaqueFunction because it is the only way to manipulate a
 # command line argument directly in the launch file
 def launch_setup(context, *args, **kwargs):
     version = LaunchConfiguration('version').perform(context)
-    # Get config path from command line, otherwise use the default path
     config_filename = LaunchConfiguration('config_file').perform(context)
     external_log_level = LaunchConfiguration('external_log_level').perform(context)
-    use_sim_time_arg = LaunchConfiguration('use_sim_time').perform(context)
+    use_sim_time = LaunchConfiguration('use_sim_time').perform(context)
     sim_mode = LaunchConfiguration('sim_mode').perform(context)
+    sim_branch_use_sim_time = 'true' if sim_mode == 'true' else use_sim_time
+    use_moveit = LaunchConfiguration('use_moveit').perform(context).lower() == 'true'
+    launch_yaw_controllers = (
+        LaunchConfiguration('launch_yaw_controllers').perform(context).lower() == 'true'
+    )
+    arm_max_cartesian_vel = float(LaunchConfiguration('arm_max_cartesian_vel').perform(context))
+    arm_max_joint_vel = float(LaunchConfiguration('arm_max_joint_vel').perform(context))
 
     arm_arg = LaunchConfiguration('arm').perform(context=context)
-    arm = True if arm_arg == 'true' else False  # bool version of arm_arg
+    arm = arm_arg == 'true'
 
-    # Parse the config file
+    description_share = get_package_share_directory('reseq_description')
+    generate_configs = subprocess.run(
+        [
+            'python3',
+            os.path.join(description_share, 'scripts', 'generate_configs.py'),
+            config_filename,
+            '--version',
+            version,
+        ]
+        + (['--use_sim_time'] if sim_branch_use_sim_time == 'true' else [])
+        + (['--no_arm_controllers'] if not arm else []),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if generate_configs.stdout:
+        print(generate_configs.stdout)
+    if generate_configs.stderr:
+        print(generate_configs.stderr)
+
     config = parse_config(f'{config_path}/{version}/{config_filename}')
-    xacro_file = description_share_folder + f'/description/{version}/reseq.urdf.xacro'
+    robot_controllers = os.path.join(description_share, 'config', 'temp', 'reseq_controllers.yaml')
+
+    xacro_file = os.path.join(description_share_folder, 'description', version, 'reseq.urdf.xacro')
     robot_description = xacro.process_file(
         xacro_file,
         mappings={
@@ -39,6 +116,7 @@ def launch_setup(context, *args, **kwargs):
             'sim_mode': sim_mode,
         },
     ).toxml()
+
     robot_state_publisher_node = Node(
         package='robot_state_publisher',
         executable='robot_state_publisher',
@@ -46,155 +124,131 @@ def launch_setup(context, *args, **kwargs):
         parameters=[
             {
                 'robot_description': robot_description,
-                'use_sim_time': use_sim_time_arg == 'true',
+                'use_sim_time': sim_branch_use_sim_time == 'true',
                 'publish_frequency': 50.0,
             }
-        ],  # add other parameters here if required
+        ],
         arguments=['--ros-args', '--log-level', external_log_level],
     )
 
     launch_config = [robot_state_publisher_node]
 
-    robot_controllers = f'{config_path}/reseq_controllers.yaml'
     if sim_mode == 'false':
         control_node = Node(
             package='controller_manager',
             executable='ros2_control_node',
-            parameters=[robot_controllers],
-            output='both',
-            remappings=[
-                ('~/robot_description', '/robot_description'),
+            parameters=[
+                {'robot_description': robot_description},
+                robot_controllers,
             ],
+            output='both',
             arguments=['--ros-args', '--log-level', external_log_level],
         )
         launch_config.append(control_node)
 
-    spawners = []
-    spawners.append(
-        Node(
-            package='controller_manager',
-            executable='spawner',
-            arguments=[
-                'joint_state_broadcaster',
-                '--controller-manager',
-                '/controller_manager',
-                '--switch-timeout',
-                '30.0',
-                '--ros-args',
-                '--log-level',
-                external_log_level,
-            ],
-        )
-    )
+    body_spawners = [_spawner('joint_state_broadcaster', external_log_level)]
 
     num_modules = config.get('num_modules', 0)
     for i in range(num_modules):
-        spawners.append(
-            Node(
-                package='controller_manager',
-                executable='spawner',
-                arguments=[
-                    f'diff_controller{i + 1}',
-                    '--controller-manager',
-                    '/controller_manager',
-                    '--switch-timeout',
-                    '30.0',
-                    '--ros-args',
-                    '--log-level',
-                    external_log_level,
-                ],
+        body_spawners.append(_spawner(f'diff_controller{i + 1}', external_log_level))
+
+    if sim_branch_use_sim_time == 'true' and launch_yaw_controllers:
+        for i in range(num_modules - 1):
+            body_spawners.append(_spawner(f'yaw_controller{i + 2}', external_log_level))
+
+    for i in range(num_modules):
+        body_spawners.append(_spawner(f'imu{i + 1}_broadcaster', external_log_level))
+
+    arm_spawners = []
+    if arm:
+        arm_spawners.append(_spawner('joint_group_velocity_controller', external_log_level))
+
+    controller_manager_ready = ExecuteProcess(
+        cmd=[
+            'zsh',
+            '-lc',
+            'until ros2 service type /controller_manager/list_controllers '
+            '> /dev/null 2>&1; do sleep 1; done',
+        ],
+        output='screen',
+    )
+
+    if sim_mode == 'false':
+        launch_config.append(
+            RegisterEventHandler(
+                OnProcessStart(target_action=control_node, on_start=[controller_manager_ready])
             )
         )
+    else:
+        launch_config.append(controller_manager_ready)
 
-    # Spawn yaw joint controllers (ForwardCommandController — sim only)
-    if use_sim_time_arg == 'true':
-        for i in range(num_modules - 1):
-            spawners.append(
-                Node(
-                    package='controller_manager',
-                    executable='spawner',
-                    arguments=[
-                        f'yaw_controller{i + 2}',
-                        '--controller-manager',
-                        '/controller_manager',
-                        '--switch-timeout',
-                        '30.0',
-                        '--ros-args',
-                        '--log-level',
-                        external_log_level,
-                    ],
-                )
-            )
+    _append_spawner_chain(launch_config, controller_manager_ready, body_spawners + arm_spawners)
 
-    # Spawn IMU sensor broadcasters (reads hardware state interfaces from either
-    # GazeboSimSystem or ReseqHardware and publishes sensor_msgs/Imu to /{name}/imu)
-    for i in range(num_modules):
-        spawners.append(
+    ekf_config = os.path.join(share_folder, 'config', 'ekf.yaml')
+    launch_config.append(
+        Node(
+            package='robot_localization',
+            executable='ekf_node',
+            name='ekf_filter_node',
+            output='screen',
+            parameters=[ekf_config, {'use_sim_time': sim_branch_use_sim_time == 'true'}],
+            arguments=['--ros-args', '--log-level', external_log_level],
+        )
+    )
+
+    if sim_mode == 'false' and arm:
+        launch_config.append(
             Node(
-                package='controller_manager',
-                executable='spawner',
-                arguments=[
-                    f'imu{i + 1}_broadcaster',
-                    '--controller-manager',
-                    '/controller_manager',
-                    '--switch-timeout',
-                    '30.0',
-                    '--ros-args',
-                    '--log-level',
-                    external_log_level,
+                package='reseq_arm_mk2',
+                executable='arm_state_bridge',
+                name='arm_state_bridge',
+                parameters=[
+                    {
+                        'source_topic': '/joint_states',
+                        'output_mode': 'joint_state',
+                        'output_topic': '/arm_joint_states',
+                    }
                 ],
+                output='screen',
             )
         )
 
     if arm:
-        spawners.append(
+        arm_state_topic = '/joint_states' if sim_mode == 'true' else '/arm_joint_states'
+        launch_config.append(
             Node(
-                package='controller_manager',
-                executable='spawner',
-                arguments=[
-                    'mk2_arm_controller',
-                    '--controller-manager',
-                    '/controller_manager',
-                    '--switch-timeout',
-                    '30.0',
+                package='reseq_arm_mk2',
+                executable='cartesian_arm_controller',
+                name='cartesian_arm_controller',
+                parameters=[
+                    {
+                        'robot_description': robot_description,
+                        'use_sim_time': sim_branch_use_sim_time == 'true',
+                        'state_topic': arm_state_topic,
+                        'chain_tip': 'tcp',
+                        'command_frame': 'arm_base_link',
+                        'command_mode': 'velocity',
+                        'max_cartesian_vel': arm_max_cartesian_vel,
+                        'max_joint_vel': arm_max_joint_vel,
+                        'startup_hold_positions': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        'deadzone': 0.02,
+                        'trajectory_horizon_sec': 0.1,
+                    }
                 ],
-            )
-        )
-        spawners.append(
-            Node(
-                package='controller_manager',
-                executable='spawner',
-                arguments=[
-                    'joint_group_velocity_controller',
-                    '--controller-manager',
-                    '/controller_manager',
-                    '--inactive',
-                    '--switch-timeout',
-                    '30.0',
-                ],
+                output='screen',
             )
         )
 
-    if spawners:
-        launch_config.append(spawners[0])
-        for previous_spawner, current_spawner in zip(spawners, spawners[1:]):
-            launch_config.append(
-                RegisterEventHandler(
-                    OnProcessExit(target_action=previous_spawner, on_exit=[current_spawner])
-                )
+    if sim_mode == 'false' and arm and use_moveit:
+        launch_config.append(
+            Node(
+                package='reseq_arm_mk2',
+                executable='coordinate_controller',
+                name='coordinate_controller',
+                parameters=[{'robot_description': robot_description}],
+                output='screen',
             )
-
-    # EKF node: fuse wheel odometry + IMU to reduce angular drift from wheel slip
-    ekf_config = os.path.join(share_folder, 'config', 'ekf.yaml')
-    ekf_node = Node(
-        package='robot_localization',
-        executable='ekf_node',
-        name='ekf_filter_node',
-        output='screen',
-        parameters=[ekf_config, {'use_sim_time': use_sim_time_arg == 'true'}],
-        arguments=['--ros-args', '--log-level', external_log_level],
-    )
-    launch_config.append(ekf_node)
+        )
 
     return launch_config
 
@@ -218,13 +272,31 @@ def generate_launch_description():
                 description=(
                     "set use_sim_time to 'true' if you are using gazebo. "
                     'In general this parameter is not set from this launch '
-                    'but instead is passed by other launch files that use '
-                    "this launch file. Setting this arg to 'true' sets the "
-                    'use_sim_time parameter of all nodes launched in this '
-                    'file to True.'
+                    'but instead is passed by other launch files that use this launch file. '
+                    "Setting this arg to 'true' sets use_sim_time on all launched nodes."
                 ),
             ),
             DeclareLaunchArgument('sim_mode', default_value='false'),
+            DeclareLaunchArgument(
+                'arm_max_cartesian_vel',
+                default_value='0.4',
+                description='Cartesian velocity scale for the arm controller',
+            ),
+            DeclareLaunchArgument(
+                'arm_max_joint_vel',
+                default_value='0.8',
+                description='Joint velocity clamp for the arm controller',
+            ),
+            DeclareLaunchArgument(
+                'use_moveit',
+                default_value='false',
+                description='Launch MoveIt-related arm tools',
+            ),
+            DeclareLaunchArgument(
+                'launch_yaw_controllers',
+                default_value='false',
+                description='Launch yaw position controllers in simulation/hardware control stack',
+            ),
             OpaqueFunction(function=launch_setup),
         ]
     )

--- a/reseq_ros2/launch/digital_twin_launch.py
+++ b/reseq_ros2/launch/digital_twin_launch.py
@@ -225,12 +225,12 @@ def launch_setup(context, *args, **kwargs):
                         'robot_description': robot_description,
                         'use_sim_time': sim_branch_use_sim_time == 'true',
                         'state_topic': arm_state_topic,
+                        'velocity_topic': '/mk2_arm_vel_scaled',
                         'chain_tip': 'tcp',
                         'command_frame': 'arm_base_link',
                         'command_mode': 'velocity',
                         'max_cartesian_vel': arm_max_cartesian_vel,
                         'max_joint_vel': arm_max_joint_vel,
-                        'startup_hold_positions': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
                         'deadzone': 0.02,
                         'trajectory_horizon_sec': 0.1,
                     }

--- a/reseq_ros2/launch/digital_twin_launch.py
+++ b/reseq_ros2/launch/digital_twin_launch.py
@@ -164,7 +164,7 @@ def launch_setup(context, *args, **kwargs):
 
     controller_manager_ready = ExecuteProcess(
         cmd=[
-            'zsh',
+            'bash',
             '-lc',
             'until ros2 service type /controller_manager/list_controllers '
             '> /dev/null 2>&1; do sleep 1; done',
@@ -217,7 +217,7 @@ def launch_setup(context, *args, **kwargs):
         launch_config.append(
             Node(
                 package='reseq_arm_mk2',
-                executable='cartesian_arm_controller',
+                executable='cartesian_arm_controller.py',
                 name='cartesian_arm_controller',
                 parameters=[
                     {
@@ -242,7 +242,7 @@ def launch_setup(context, *args, **kwargs):
         launch_config.append(
             Node(
                 package='reseq_arm_mk2',
-                executable='coordinate_controller',
+                executable='coordinate_controller.py',
                 name='coordinate_controller',
                 parameters=[{'robot_description': robot_description}],
                 output='screen',

--- a/reseq_ros2/launch/digital_twin_launch.py
+++ b/reseq_ros2/launch/digital_twin_launch.py
@@ -156,12 +156,11 @@ def launch_setup(context, *args, **kwargs):
         for i in range(num_modules - 1):
             body_spawners.append(_spawner(f'yaw_controller{i + 2}', external_log_level))
 
+    if arm:
+        body_spawners.append(_spawner('joint_group_velocity_controller', external_log_level))
+
     for i in range(num_modules):
         body_spawners.append(_spawner(f'imu{i + 1}_broadcaster', external_log_level))
-
-    arm_spawners = []
-    if arm:
-        arm_spawners.append(_spawner('joint_group_velocity_controller', external_log_level))
 
     controller_manager_ready = ExecuteProcess(
         cmd=[
@@ -182,7 +181,7 @@ def launch_setup(context, *args, **kwargs):
     else:
         launch_config.append(controller_manager_ready)
 
-    _append_spawner_chain(launch_config, controller_manager_ready, body_spawners + arm_spawners)
+    _append_spawner_chain(launch_config, controller_manager_ready, body_spawners)
 
     ekf_config = os.path.join(share_folder, 'config', 'ekf.yaml')
     launch_config.append(

--- a/reseq_ros2/launch/reseq_core_launch.py
+++ b/reseq_ros2/launch/reseq_core_launch.py
@@ -1,5 +1,5 @@
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.actions import DeclareLaunchArgument, EmitEvent, OpaqueFunction
 from launch.events import Shutdown
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
@@ -42,7 +42,7 @@ def launch_setup(context, *args, **kwargs):
                 }
             ],
             arguments=['--ros-args', '--log-level', log_level],
-            on_exit=Shutdown(),
+            on_exit=[EmitEvent(event=Shutdown())],
         )
     )
     launch_config.append(
@@ -57,7 +57,7 @@ def launch_setup(context, *args, **kwargs):
                 }
             ],
             arguments=['--ros-args', '--log-level', log_level],
-            on_exit=Shutdown(),
+            on_exit=[EmitEvent(event=Shutdown())],
         )
     )
 
@@ -76,7 +76,7 @@ def launch_setup(context, *args, **kwargs):
                 }
             ],
             arguments=['--ros-args', '--log-level', log_level],
-            on_exit=Shutdown(),
+            on_exit=[EmitEvent(event=Shutdown())],
         )
     )
 

--- a/reseq_ros2/launch/reseq_core_launch.py
+++ b/reseq_ros2/launch/reseq_core_launch.py
@@ -71,6 +71,11 @@ def launch_setup(context, *args, **kwargs):
                     'r_linear_vel': config['scaler_consts']['r_linear_vel'],
                     'r_inverse_radius': config['scaler_consts']['r_inverse_radius'],
                     'r_angular_vel': config['scaler_consts']['r_angular_vel'],
+                    'arm_input_scale': config['scaler_consts'].get('arm_input_scale', 1.0),
+                    'arm_input_deadzone': config['scaler_consts'].get('arm_input_deadzone', 0.08),
+                    'arm_vel_topic': config['scaler_consts'].get(
+                        'arm_vel_topic', '/mk2_arm_vel_scaled'
+                    ),
                     'version': config['version'],
                     'use_sim_time': use_sim_time,
                 }

--- a/reseq_ros2/launch/reseq_launch.py
+++ b/reseq_ros2/launch/reseq_launch.py
@@ -41,7 +41,10 @@ def launch_setup(context, *args, **kwargs):
     # use simulation time: should only be used with gazebo that's why default value is 'false'
     use_sim_time = LaunchConfiguration('use_sim_time').perform(context)
     sim_mode = LaunchConfiguration('sim_mode').perform(context)
-
+    use_moveit = LaunchConfiguration('use_moveit').perform(context)
+    launch_yaw_controllers = LaunchConfiguration('launch_yaw_controllers').perform(context)
+    arm_max_cartesian_vel = LaunchConfiguration('arm_max_cartesian_vel').perform(context)
+    arm_max_joint_vel = LaunchConfiguration('arm_max_joint_vel').perform(context)
     arm_arg = LaunchConfiguration('arm').perform(context=context)
     arm = True if arm_arg == 'true' else False
 
@@ -132,42 +135,35 @@ def launch_setup(context, *args, **kwargs):
                     'map_file': map_file,
                     'spawn_x': spawn_x,
                     'spawn_y': spawn_y,
+                    'wait_for_odom': 'true' if sim_mode == 'true' else 'false',
                 }.items(),
             )
         )
 
-    if digital_twin_enabled == 'true':
-        # Digital twin launch file
-        digital_twin_launch_file = os.path.join(
-            get_package_share_directory('reseq_ros2'), 'launch', 'digital_twin_launch.py'
+    # The digital_twin launch owns robot_description and ros2_control setup.
+    # In Gazebo it publishes the full MK2 model and lets gz_ros2_control provide
+    # /controller_manager; on hardware it starts ros2_control_node directly.
+    digital_twin_launch_file = os.path.join(
+        get_package_share_directory('reseq_ros2'), 'launch', 'digital_twin_launch.py'
+    )
+    launch_config.append(
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(digital_twin_launch_file),
+            launch_arguments={
+                'version': version,
+                'config_file': config_filename,
+                'arm': arm_arg,
+                'log_level': log_level,
+                'external_log_level': external_log_level,
+                'use_sim_time': use_sim_time,
+                'sim_mode': sim_mode,
+                'arm_max_cartesian_vel': arm_max_cartesian_vel,
+                'arm_max_joint_vel': arm_max_joint_vel,
+                'use_moveit': use_moveit,
+                'launch_yaw_controllers': launch_yaw_controllers,
+            }.items(),
         )
-        launch_config.append(
-            IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(digital_twin_launch_file),
-                launch_arguments={
-                    'version': version,
-                    'config_file': config_filename,
-                    'arm': arm_arg,
-                    'log_level': log_level,
-                    'external_log_level': external_log_level,
-                    'use_sim_time': use_sim_time,
-                    'sim_mode': sim_mode,
-                }.items(),
-            )
-        )
-
-    if arm:
-        arm_launch_file = os.path.join(
-            get_package_share_directory('reseq_arm_mk2'), 'launch', 'arm.launch.py'
-        )
-        launch_config.append(
-            IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(arm_launch_file),
-                launch_arguments={
-                    'use_sim_time': use_sim_time,
-                }.items(),
-            )
-        )
+    )
 
     # App launch file
     app_enabled = LaunchConfiguration('app').perform(context)
@@ -316,6 +312,18 @@ def generate_launch_description():
             # this argument is passed as 'true' by sim_launch.py file
             DeclareLaunchArgument('use_sim_time', default_value='false'),
             DeclareLaunchArgument('sim_mode', default_value='false'),
+            DeclareLaunchArgument(
+                'arm_max_cartesian_vel',
+                default_value='0.4',
+                description='Cartesian velocity scale for the arm controller',
+            ),
+            DeclareLaunchArgument(
+                'arm_max_joint_vel',
+                default_value='0.8',
+                description='Joint velocity clamp for the arm controller',
+            ),
+            DeclareLaunchArgument('use_moveit', default_value='false'),
+            DeclareLaunchArgument('launch_yaw_controllers', default_value='false'),
             DeclareLaunchArgument('no_body_controllers', default_value='false'),
             DeclareLaunchArgument('no_arm_controllers', default_value='false'),
             OpaqueFunction(function=generate_config_setup),

--- a/reseq_ros2/launch/slam_launch.py
+++ b/reseq_ros2/launch/slam_launch.py
@@ -39,7 +39,7 @@ def generate_launch_description():
     use_sim_time_arg = DeclareLaunchArgument('use_sim_time', default_value='false')
     ply_save_path_arg = DeclareLaunchArgument(
         'ply_save_path',
-        default_value=os.environ.get('RESEQ_PLY_SAVE_PATH', '/tmp/reseq_maps'),
+        default_value=os.environ.get('RESEQ_PLY_SAVE_PATH', '/ros2_ws/maps'),
         description='Directory where ply_saver writes the 3D map',
     )
 

--- a/reseq_ros2/launch/slam_launch.py
+++ b/reseq_ros2/launch/slam_launch.py
@@ -37,18 +37,43 @@ def generate_launch_description():
     )
 
     use_sim_time_arg = DeclareLaunchArgument('use_sim_time', default_value='false')
+    ply_save_path_arg = DeclareLaunchArgument(
+        'ply_save_path',
+        default_value=os.environ.get('RESEQ_PLY_SAVE_PATH', '/tmp/reseq_maps'),
+        description='Directory where ply_saver writes the 3D map',
+    )
 
     slam_node = Node(
         package='slam_toolbox',
         executable='async_slam_toolbox_node',
         name='slam_toolbox',
         output='screen',
+        remappings=[
+            ('/map', '/slam_map'),
+            ('/map_metadata', '/slam_map_metadata'),
+        ],
         parameters=[
             LaunchConfiguration('slam_params_file'),
             {
                 'use_sim_time': LaunchConfiguration('use_sim_time'),
                 'mode': LaunchConfiguration('slam_mode'),
             },
+        ],
+    )
+
+    map_republisher_node = Node(
+        package='reseq_ros2',
+        executable='map_republisher',
+        name='map_republisher',
+        output='screen',
+        parameters=[
+            {
+                'use_sim_time': LaunchConfiguration('use_sim_time'),
+                'input_topic': '/slam_map',
+                'output_topic': '/map',
+                'metadata_topic': '/map_metadata',
+                'publish_rate': 1.0,
+            }
         ],
     )
 
@@ -77,7 +102,7 @@ def generate_launch_description():
             {
                 'use_sim_time': LaunchConfiguration('use_sim_time'),
                 'pointcloud_topic': '/camera/depth/color/points',
-                'save_path': '/ros2_ws/maps',
+                'save_path': LaunchConfiguration('ply_save_path'),
                 'save_interval': 60.0,
                 'voxel_size': 0.05,
                 'frame_skip': 5,
@@ -98,7 +123,9 @@ def generate_launch_description():
             slam_mode_arg,
             params_arg,
             use_sim_time_arg,
+            ply_save_path_arg,
             slam_node,
+            map_republisher_node,
             lifecycle_manager,
             ply_saver_node,
         ]

--- a/reseq_ros2/reseq_ros2/map_republisher.py
+++ b/reseq_ros2/reseq_ros2/map_republisher.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Republish the latest map periodically for app clients.
+
+SLAM Toolbox publishes /map with transient-local durability. That is correct
+for Nav2, but rosbridge/web clients can miss the latched sample when they
+connect before the map exists. This relay keeps publishing the latest map so
+the app gets a normal fresh OccupancyGrid without requiring a reconnect.
+"""
+
+import rclpy
+from nav_msgs.msg import MapMetaData, OccupancyGrid
+from rclpy.duration import Duration
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+
+
+def _map_qos() -> QoSProfile:
+    return QoSProfile(
+        history=HistoryPolicy.KEEP_LAST,
+        depth=1,
+        reliability=ReliabilityPolicy.RELIABLE,
+        durability=DurabilityPolicy.TRANSIENT_LOCAL,
+    )
+
+
+class MapRepublisher(Node):
+    def __init__(self) -> None:
+        super().__init__('map_republisher')
+        self.input_topic = self.declare_parameter('input_topic', '/slam_map').value
+        self.output_topic = self.declare_parameter('output_topic', '/map').value
+        self.metadata_topic = self.declare_parameter('metadata_topic', '/map_metadata').value
+        self.publish_rate = float(self.declare_parameter('publish_rate', 1.0).value)
+        self.stamp_with_now = bool(self.declare_parameter('stamp_with_now', False).value)
+
+        qos = _map_qos()
+        self.map_pub = self.create_publisher(OccupancyGrid, self.output_topic, qos)
+        self.metadata_pub = self.create_publisher(MapMetaData, self.metadata_topic, qos)
+        self.create_subscription(OccupancyGrid, self.input_topic, self._map_callback, qos)
+
+        self.latest_map: OccupancyGrid | None = None
+        self.timer = self.create_timer(1.0 / max(self.publish_rate, 0.1), self._publish_latest)
+        self.get_logger().info(
+            f'MapRepublisher ready | {self.input_topic} -> {self.output_topic} '
+            f'at {self.publish_rate:.2f} Hz'
+        )
+
+    def _map_callback(self, msg: OccupancyGrid) -> None:
+        self.latest_map = msg
+        self._publish_latest()
+
+    def _publish_latest(self) -> None:
+        if self.latest_map is None:
+            return
+
+        msg = OccupancyGrid()
+        msg.header = self.latest_map.header
+        msg.info = self.latest_map.info
+        msg.data = self.latest_map.data
+
+        if self.stamp_with_now:
+            msg.header.stamp = self.get_clock().now().to_msg()
+            msg.info.map_load_time = msg.header.stamp
+        elif msg.header.stamp.sec == 0 and msg.header.stamp.nanosec == 0:
+            msg.header.stamp = self.get_clock().now().to_msg()
+
+        self.map_pub.publish(msg)
+        self.metadata_pub.publish(msg.info)
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = MapRepublisher()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/reseq_ros2/reseq_ros2/ply_saver.py
+++ b/reseq_ros2/reseq_ros2/ply_saver.py
@@ -196,9 +196,6 @@ class PlySaver(Node):
         pts_map = (R @ pts.T).T + t
         self._accumulate_pts(pts_map, rgb)
 
-        if self._frame_idx % (self._frame_skip * 30) == 0:
-            self.get_logger().info(f'PlySaver: {len(self._voxel_map)} voxels accumulated')
-
     def _scan_cb(self, msg: LaserScan) -> None:
         self._scan_frame_idx += 1
         if self._scan_frame_idx % max(1, self._scan_frame_skip) != 0:
@@ -240,11 +237,6 @@ class PlySaver(Node):
         pts_map = (R @ pts_scan.T).T + t
         scan_rgb = np.tile(np.array(self._scan_rgb, dtype=np.uint8), (len(pts_map), 1))
         self._accumulate_pts(pts_map, scan_rgb)
-
-        if self._scan_frame_idx % (max(1, self._scan_frame_skip) * 30) == 0:
-            self.get_logger().info(
-                f'PlySaver: {len(self._voxel_map)} voxels accumulated (camera+scan)'
-            )
 
     def _save(self) -> None:
         n = len(self._voxel_map)

--- a/reseq_ros2/reseq_ros2/ply_saver.py
+++ b/reseq_ros2/reseq_ros2/ply_saver.py
@@ -14,9 +14,11 @@ with pointcloud.enable:=true also uses RELIABLE, so this works on both platforms
 """
 
 from pathlib import Path
+from std_msgs.msg import Header
 
 import numpy as np
 import rclpy
+import sensor_msgs_py.point_cloud2 as pc2
 import tf2_ros
 from rclpy.node import Node
 from rclpy.qos import (
@@ -26,6 +28,7 @@ from rclpy.qos import (
     QoSReliabilityPolicy,
 )
 from sensor_msgs.msg import LaserScan, PointCloud2
+from sensor_msgs.msg import PointField
 
 
 def _parse_xyz_rgb(msg: PointCloud2):
@@ -39,7 +42,7 @@ def _parse_xyz_rgb(msg: PointCloud2):
     if not all(k in fields for k in ('x', 'y', 'z', 'rgb')):
         return None, None
 
-    ox, oy, oz = fields['x'][0], fields['y'][0], fields['z'][0]
+    ox = fields['x'][0]
     o_rgb, rgb_dt = fields['rgb']
     step = msg.point_step
     n = msg.width * msg.height
@@ -95,6 +98,7 @@ class PlySaver(Node):
         self.declare_parameter('pointcloud_topic', '/camera/depth/color/points')
         self.declare_parameter('save_path', '/ros2_ws/maps')
         self.declare_parameter('save_interval', 60.0)
+        self.declare_parameter('publish_interval', 5.0)
         self.declare_parameter('voxel_size', 0.05)
         self.declare_parameter('frame_skip', 5)
         self.declare_parameter('max_range', 10.0)
@@ -106,6 +110,9 @@ class PlySaver(Node):
         self._pc_topic = self.get_parameter('pointcloud_topic').get_parameter_value().string_value
         save_dir = Path(self.get_parameter('save_path').get_parameter_value().string_value)
         interval = self.get_parameter('save_interval').get_parameter_value().double_value
+        publish_interval = (
+            self.get_parameter('publish_interval').get_parameter_value().double_value
+        )
         self._voxel_size = self.get_parameter('voxel_size').get_parameter_value().double_value
         self._frame_skip = self.get_parameter('frame_skip').get_parameter_value().integer_value
         self._max_range = self.get_parameter('max_range').get_parameter_value().double_value
@@ -120,6 +127,7 @@ class PlySaver(Node):
         self._scan_rgb = tuple(int(max(0, min(255, c))) for c in scan_rgb[:3])
 
         self._ply_path = save_dir / 'reseq_map_3d.ply'
+        self._map_topic = '/ply_map/points'
         self._voxel_map = {}
         self._frame_idx: int = 0
         self._scan_frame_idx: int = 0
@@ -152,7 +160,10 @@ class PlySaver(Node):
             scan_qos,
         )
 
+        self._map_pub = self.create_publisher(PointCloud2, self._map_topic, pc_qos)
+
         self.create_timer(interval, self._save)
+        self.create_timer(publish_interval, self._publish_map_cloud)
         self.get_logger().info(
             f'PlySaver listening on [{self._pc_topic}] and [{self._scan_topic}], '
             f'save every {interval:.0f}s -> {self._ply_path}'
@@ -165,6 +176,41 @@ class PlySaver(Node):
         voxel_keys = tuple(np.floor(pts_map[:, i] / vs).astype(np.int64) for i in range(3))
         for k0, k1, k2, c in zip(*voxel_keys, rgb):
             self._voxel_map[(int(k0), int(k1), int(k2))] = (int(c[0]), int(c[1]), int(c[2]))
+
+    def _voxel_map_to_pointcloud(self) -> PointCloud2 | None:
+        if not self._voxel_map:
+            return None
+
+        vs = self._voxel_size
+        items = list(self._voxel_map.items())
+        keys = np.array([k for k, _ in items], dtype=np.int64)
+        colors = np.array([v for _, v in items], dtype=np.uint8)
+        pts = keys.astype(np.float64) * vs + vs / 2.0
+
+        rgb_uint32 = (
+            (colors[:, 0].astype(np.uint32) << 16)
+            | (colors[:, 1].astype(np.uint32) << 8)
+            | colors[:, 2].astype(np.uint32)
+        )
+        rgb_float = rgb_uint32.view(np.float32)
+
+        header = Header()
+        header.stamp = self.get_clock().now().to_msg()
+        header.frame_id = 'map'
+        fields = [
+            PointField(name='x', offset=0, datatype=PointField.FLOAT32, count=1),
+            PointField(name='y', offset=4, datatype=PointField.FLOAT32, count=1),
+            PointField(name='z', offset=8, datatype=PointField.FLOAT32, count=1),
+            PointField(name='rgb', offset=12, datatype=PointField.FLOAT32, count=1),
+        ]
+        cloud_rows = np.column_stack((pts.astype(np.float32), rgb_float.astype(np.float32)))
+        return pc2.create_cloud(header, fields, cloud_rows.tolist())
+
+    def _publish_map_cloud(self) -> None:
+        cloud_msg = self._voxel_map_to_pointcloud()
+        if cloud_msg is None:
+            return
+        self._map_pub.publish(cloud_msg)
 
     def _pc_cb(self, msg: PointCloud2) -> None:
         self._frame_idx += 1

--- a/reseq_ros2/reseq_ros2/scaler.py
+++ b/reseq_ros2/reseq_ros2/scaler.py
@@ -154,13 +154,14 @@ class Scaler(Node):
         # inverse of Radius of curvature (AGEVAR) or angular velocity (PIVOT) (-1:1)
         cmd_vel.angular.z = -data.right.x
 
-        # TODO probably to merge with another version of scaler.py
-
-        self.moveit_pub.publish(
+        # The app joystick is screen-oriented: X is right/left, Y is forward/back.
+        # The arm controller expects Cartesian commands in arm_base_link:
+        # +X forward, +Y left, +Z up. Invert screen X so pushing right moves right.
+        self.arm_vel_pub.publish(
             Vector3(
-                x=data.left.x,
-                y=data.left.y,
-                z=data.left.z,
+                x=self.scale_arm_input(data.left.y),
+                y=self.scale_arm_input(-data.left.x),
+                z=self.scale_arm_input(data.left.z),
             )
         )
 
@@ -183,6 +184,17 @@ class Scaler(Node):
 
     def scale(self, val, scaling_range):
         return (val + 1) / 2 * (scaling_range[1] - scaling_range[0]) + scaling_range[0]
+
+    def scale_arm_input(self, val: float) -> float:
+        value = float(val)
+        magnitude = abs(value)
+        if magnitude <= self.arm_input_deadzone:
+            return 0.0
+
+        span = max(1.0 - self.arm_input_deadzone, 1e-6)
+        scaled = ((magnitude - self.arm_input_deadzone) / span) * self.arm_input_scale
+        scaled = max(-1.0, min(1.0, scaled))
+        return scaled if value >= 0.0 else -scaled
 
 
 def main(args=None):

--- a/reseq_ros2/reseq_ros2/scaler.py
+++ b/reseq_ros2/reseq_ros2/scaler.py
@@ -177,9 +177,16 @@ class Scaler(Node):
         return data
 
     def agevarScaler(self, data: Twist):
-        data.linear.x = self.scale(data.linear.x, self.r_linear_vel)
-        data.angular.z = self.scale(data.angular.z, self.r_inverse_radius)
-        data.angular.z *= data.linear.x  # Angular vel
+        linear_input = data.linear.x
+        angular_input = data.angular.z
+
+        data.linear.x = self.scale(linear_input, self.r_linear_vel)
+        if abs(linear_input) <= 0.08 and abs(angular_input) > 0.08:
+            data.linear.x = 0.0
+            data.angular.z = self.scale(angular_input, self.r_angular_vel)
+        else:
+            data.angular.z = self.scale(angular_input, self.r_inverse_radius)
+            data.angular.z *= data.linear.x  # Angular vel
         return data
 
     def scale(self, val, scaling_range):

--- a/reseq_ros2/reseq_ros2/scaler.py
+++ b/reseq_ros2/reseq_ros2/scaler.py
@@ -98,13 +98,20 @@ class Scaler(Node):
             .get_parameter_value()
             .double_array_value
         )
+        self.arm_input_scale = (
+            self.declare_parameter('arm_input_scale', 1.0).get_parameter_value().double_value
+        )
+        self.arm_input_deadzone = (
+            self.declare_parameter('arm_input_deadzone', 0.08).get_parameter_value().double_value
+        )
+        arm_vel_topic = self.declare_parameter('arm_vel_topic', '/mk2_arm_vel').value
 
         for h in self.handlers:
             h['service'] = self.create_client(SetBool, h['service'])
 
         self.create_subscription(Remote, '/remote', self.remote_callback, self.qos)
 
-        self.moveit_pub = self.create_publisher(Vector3, '/mk2_arm_vel', 10)
+        self.arm_vel_pub = self.create_publisher(Vector3, arm_vel_topic, 10)
 
         self.speed_pub = self.create_publisher(Twist, '/cmd_vel_teleop', 10)
         self.autonomy_pub = self.create_publisher(Bool, '/autonomy/enabled', 10)

--- a/reseq_ros2/setup.py
+++ b/reseq_ros2/setup.py
@@ -40,6 +40,7 @@ setup(
             'thermal_pointcloud_fusion = reseq_ros2.thermal_pointcloud_fusion:main',
             'user_path_publisher = reseq_ros2.user_path_publisher:main',
             'ply_saver = reseq_ros2.ply_saver:main',
+            'map_republisher = reseq_ros2.map_republisher:main',
         ],
     },
 )

--- a/reseq_sim/launch/mk2.launch.py
+++ b/reseq_sim/launch/mk2.launch.py
@@ -41,6 +41,7 @@ def launch_setup(context, *args, **kwargs):
             'map_file': LaunchConfiguration('map_file'),
             'spawn_x': LaunchConfiguration('spawn_x'),
             'spawn_y': LaunchConfiguration('spawn_y'),
+            'launch_yaw_controllers': 'true',
         }.items(),
     )
 


### PR DESCRIPTION
## Summary

This PR fixes the MK2 simulation/app control path after the auto-nav rebase. It stabilizes the full sim launch with autonomy and arm enabled, routes Flutter arm joystick commands through a scaler-owned topic, corrects Cartesian arm joystick axis mapping, and restores base turning by spawning the MK2 yaw controllers in simulation.

## Changes

- Stabilize `ros2 launch reseq_sim mk2.launch.py autonomy:=true arm:=true`
- Route app arm commands through `/mk2_arm_vel_scaled`
- Map Flutter arm joystick axes into the Cartesian arm frame correctly
- Prioritize drive controller spawning so base teleop is not blocked by arm startup
- Allow pure right-stick AGEVAR turn input to produce angular velocity
- Spawn MK2 yaw controllers in sim so the base can turn left/right from the joystick

## Tested

- Built affected packages with `colcon build`
- Tested MK2 sim launch with autonomy and arm enabled
- Verified Flutter app arm joystick moves the arm correctly
- Verified base forward/back movement
- Verified base left/right turning after enabling yaw controller launch
