### PR TITLE
Add end-effector linear and rotation arm control modes

### DIFF
--- a/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
+++ b/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
@@ -173,6 +173,55 @@ def _unwrap_joint_positions(
     return unwrapped_q
 
 
+def _rotation_matrix_from_rpy(roll: float, pitch: float, yaw: float) -> np.ndarray:
+    """Return a base-to-tool rotation matrix from fixed-axis RPY angles."""
+    cr, sr = np.cos(roll), np.sin(roll)
+    cp, sp = np.cos(pitch), np.sin(pitch)
+    cy, sy = np.cos(yaw), np.sin(yaw)
+
+    rx = np.array([[1.0, 0.0, 0.0], [0.0, cr, -sr], [0.0, sr, cr]])
+    ry = np.array([[cp, 0.0, sp], [0.0, 1.0, 0.0], [-sp, 0.0, cp]])
+    rz = np.array([[cy, -sy, 0.0], [sy, cy, 0.0], [0.0, 0.0, 1.0]])
+    return rz @ ry @ rx
+
+
+def _rotation_error_vector(current_rotation: np.ndarray, desired_rotation: np.ndarray) -> np.ndarray:
+    """Return the base-frame angular correction from current to desired orientation."""
+    r_err = desired_rotation @ current_rotation.T
+    cos_theta = float(np.clip((np.trace(r_err) - 1.0) * 0.5, -1.0, 1.0))
+    theta = float(np.arccos(cos_theta))
+    skew_vec = np.array(
+        [
+            r_err[2, 1] - r_err[1, 2],
+            r_err[0, 2] - r_err[2, 0],
+            r_err[1, 0] - r_err[0, 1],
+        ]
+    )
+    if theta < 1e-6:
+        return 0.5 * skew_vec
+
+    sin_theta = float(np.sin(theta))
+    if abs(sin_theta) < 1e-6:
+        return np.zeros(3)
+    return (theta / (2.0 * sin_theta)) * skew_vec
+
+
+def _rotation_mode_angular_velocity(cmd_vel: np.ndarray, max_angular_vel: float) -> np.ndarray:
+    """Map scaler arm input to robot-frame roll, tilt, and pan angular velocity."""
+    return max_angular_vel * np.array(
+        [
+            cmd_vel[0],  # roll around robot/tool-forward X
+            cmd_vel[2],  # tilt around robot Y
+            cmd_vel[1],  # pan/yaw around robot Z
+        ],
+        dtype=float,
+    )
+
+
+def _clip_vector(vec: np.ndarray, limit: float) -> np.ndarray:
+    return np.clip(vec, -abs(limit), abs(limit))
+
+
 def _solve_weighted_dls_task_velocity(
     task_jacobian: np.ndarray,
     cart_vel: np.ndarray,
@@ -189,6 +238,21 @@ def _solve_weighted_dls_task_velocity(
             jj_t + damping**2 * np.eye(task_jacobian.shape[0]),
             cart_vel,
         )
+    )
+
+
+def _weighted_dls_pseudoinverse(
+    task_jacobian: np.ndarray,
+    joint_weights: np.ndarray,
+    damping: float,
+) -> np.ndarray:
+    """Return the weighted DLS pseudo-inverse for a task Jacobian."""
+    inv_joint_weights = np.diag(1.0 / joint_weights)
+    jj_t = task_jacobian @ inv_joint_weights @ task_jacobian.T
+    return (
+        inv_joint_weights
+        @ task_jacobian.T
+        @ np.linalg.inv(jj_t + damping**2 * np.eye(task_jacobian.shape[0]))
     )
 
 
@@ -262,6 +326,65 @@ def _solve_task_velocity_with_limit_redistribution(
     return dq_final, clipped_joints, vel_scale
 
 
+def _solve_prioritized_task_velocity(
+    current_q: np.ndarray,
+    primary_jacobian: np.ndarray,
+    primary_vel: np.ndarray,
+    secondary_jacobian: np.ndarray | None,
+    secondary_vel: np.ndarray | None,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+    dt: float,
+    max_joint_vel: float,
+    damping: float,
+    joint_weights: np.ndarray,
+    secondary_weight: float,
+) -> tuple[np.ndarray, list[str], float]:
+    """Solve the primary task and optionally add a nullspace secondary task."""
+    dq, joints_clipped, vel_scale = _solve_task_velocity_with_limit_redistribution(
+        current_q=current_q,
+        task_jacobian=primary_jacobian,
+        cart_vel=primary_vel,
+        q_lo=q_lo,
+        q_hi=q_hi,
+        dt=dt,
+        max_joint_vel=max_joint_vel,
+        damping=damping,
+        joint_weights=joint_weights,
+    )
+
+    if (
+        secondary_jacobian is None
+        or secondary_vel is None
+        or secondary_weight <= 0.0
+        or secondary_jacobian.size == 0
+    ):
+        return dq, joints_clipped, vel_scale
+
+    pinv_primary = _weighted_dls_pseudoinverse(primary_jacobian, joint_weights, damping)
+    nullspace = np.eye(primary_jacobian.shape[1]) - pinv_primary @ primary_jacobian
+    residual = secondary_vel - secondary_jacobian @ dq
+    projected_secondary = secondary_jacobian @ nullspace
+    if np.linalg.norm(projected_secondary) < 1e-9 or np.linalg.norm(residual) < 1e-9:
+        return dq, joints_clipped, vel_scale
+
+    dq_secondary = nullspace @ _solve_weighted_dls_task_velocity(
+        task_jacobian=projected_secondary,
+        cart_vel=secondary_weight * residual,
+        joint_weights=joint_weights,
+        damping=damping,
+    )
+    dq_candidate = dq + dq_secondary
+    peak = float(np.max(np.abs(dq_candidate)))
+    if peak > max_joint_vel:
+        vel_scale = min(vel_scale, max_joint_vel / peak)
+        dq_candidate *= max_joint_vel / peak
+    dq_candidate = _clamp_joint_velocity_to_limits(
+        current_q, dq_candidate, q_lo, q_hi, dt
+    )
+    return dq_candidate, joints_clipped, vel_scale
+
+
 def _joint_limit_hold_scale(
     current_q: np.ndarray,
     q_lo: np.ndarray,
@@ -331,12 +454,18 @@ class CartesianArmController(Node):
     control_rate           float  33.0   Hz
     max_cartesian_vel      float  0.3    m/s  (joystick [-1,1] scaled by this)
     max_joint_vel          float  1.0    rad/s per joint
+    max_angular_vel        float  0.8    rad/s for camera pan/tilt/roll commands
     home_duration_sec      float  3.0    s
     trajectory_horizon_sec float  0.10   s
     command_mode           str    'trajectory' or 'velocity'
     deadzone               float  0.02
     jacobian_damping       float  0.05   damped-LS regularisation λ
     joint_weights          float[]  joint weighting for the IK solve
+    robot_forward_rpy      float[] fixed tool orientation for "camera forward"
+    orientation_hold_gain  float  proportional gain for forward orientation hold
+    orientation_task_weight float weight for linear-mode orientation hold
+    position_hold_gain     float  proportional gain for rotation-mode position hold
+    secondary_task_weight  float  weight for nullspace angular task
     """
 
     # Joint order used everywhere in this controller.
@@ -373,6 +502,7 @@ class CartesianArmController(Node):
         self.declare_parameter('trajectory_topic', '/mk2_arm_controller/joint_trajectory')
         self.declare_parameter('control_rate', 33.0)
         self.declare_parameter('max_cartesian_vel', 0.6)
+        self.declare_parameter('max_angular_vel', 0.8)
         self.declare_parameter('max_joint_vel', 0.5)
         self.declare_parameter('home_duration_sec', 3.0)
         self.declare_parameter('trajectory_horizon_sec', 0.10)
@@ -384,6 +514,11 @@ class CartesianArmController(Node):
         self.declare_parameter('idle_hold_gain', 1.5)
         self.declare_parameter('idle_hold_tolerance', 0.01)
         self.declare_parameter('front_branch_gain', 0.05)
+        self.declare_parameter('robot_forward_rpy', [0.0, 0.0, 0.0])
+        self.declare_parameter('orientation_hold_gain', 1.0)
+        self.declare_parameter('orientation_task_weight', 0.8)
+        self.declare_parameter('position_hold_gain', 2.0)
+        self.declare_parameter('secondary_task_weight', 1.0)
 
         # Internal state.
         self._q: np.ndarray | None = None  # measured joint positions
@@ -394,9 +529,19 @@ class CartesianArmController(Node):
         self._velocity_mode = True
         self._moving = False
         self._ee_z_ref: float | None = None
+        self._ee_pos_ref: np.ndarray | None = None
         self._front_x_ref: float | None = None
         self._front_branch_gain = (
             self.get_parameter('front_branch_gain').get_parameter_value().double_value
+        )
+        forward_rpy = list(self.get_parameter('robot_forward_rpy').value)
+        if len(forward_rpy) != 3:
+            self.get_logger().warn('robot_forward_rpy must have 3 values; using [0, 0, 0].')
+            forward_rpy = [0.0, 0.0, 0.0]
+        self._forward_rotation = _rotation_matrix_from_rpy(
+            float(forward_rpy[0]),
+            float(forward_rpy[1]),
+            float(forward_rpy[2]),
         )
         self._diag_ctr = 0
         self._home_active = False
@@ -652,6 +797,17 @@ class CartesianArmController(Node):
             return None
         return frame
 
+    def _rotation_kdl_to_matrix(self, rotation) -> np.ndarray:
+        return np.array([[rotation[r, c] for c in range(3)] for r in range(3)], dtype=float)
+
+    def _get_ee_rotation(self, q: np.ndarray) -> np.ndarray | None:
+        if self._fk_solver is None:
+            return None
+        frame = self._fk_frame_kdl(q)
+        if frame is None:
+            return None
+        return self._rotation_kdl_to_matrix(frame.M)
+
     def _fk_numerical(self, q: np.ndarray) -> np.ndarray:
         """
         Simple FK fallback for cases where KDL is not available.
@@ -827,6 +983,8 @@ class CartesianArmController(Node):
                 self._publish_traj(self._q.tolist(), hold_target, 0.1)
             self._moving = False
             self._ee_z_ref = None
+            if self._linear_mode:
+                self._ee_pos_ref = None
             return
 
         # Solve from the live measured pose so the Jacobian tracks the actual arm.
@@ -837,64 +995,125 @@ class CartesianArmController(Node):
         if self._ee_z_ref is None:
             self._ee_z_ref = float(self._get_ee_pos(solve_q)[2])
 
-        if not self._linear_mode:
-            # Orientation mode is not implemented yet.
-            return
-
         # Control parameters.
         max_cv = self.get_parameter('max_cartesian_vel').get_parameter_value().double_value
+        max_av = self.get_parameter('max_angular_vel').get_parameter_value().double_value
         max_jv = self.get_parameter('max_joint_vel').get_parameter_value().double_value
         lam = self.get_parameter('jacobian_damping').get_parameter_value().double_value
         horizon = self.get_parameter('trajectory_horizon_sec').get_parameter_value().double_value
         horizon = max(horizon, self._dt * 2.0)  # never shorter than 2 control ticks
 
-        # Interpret the input in the configured command frame, then solve in base coordinates.
-        cart_vel_cmd = self._cmd_vel * max_cv
-        cart_vel = self._command_velocity_in_base(solve_q, cart_vel_cmd)
-
-        # Hold the current height unless the user is explicitly commanding Z.
-        # This keeps lateral motion from slowly climbing as the arm changes posture.
-        if self._ee_z_ref is not None and abs(cart_vel_cmd[2]) < deadzone:
-            z_error = self._ee_z_ref - float(self._get_ee_pos(solve_q)[2])
-            z_hold_vel = 2.0 * z_error
-            hold_scale = _joint_limit_hold_scale(solve_q, self._q_lo, self._q_hi)
-            # Relax the height hold near saturation so a reverse x/y command can
-            # back the arm away from the limit instead of fighting the stale z target.
-            cart_vel[2] = float(np.clip(z_hold_vel * hold_scale, -max_cv, max_cv))
-
-        if self._front_x_ref is not None and abs(cart_vel_cmd[0]) < deadzone:
-            x_error = self._front_x_ref - float(self._get_ee_pos(solve_q)[0])
-            if x_error > 0.0:
-                # Keep lateral motion on the front side of the workspace unless the
-                # operator is explicitly commanding X.
-                cart_vel[0] = float(np.clip(2.0 * x_error, 0.0, max_cv))
-
         J = self._get_jacobian(solve_q)
         if J is None:
             return
 
-        # Damped least-squares IK on the tool translational task.
+        active_dofs = J.shape[1]
+        Jlin = J[:3, :active_dofs]
+        cart_vel_cmd = self._cmd_vel * max_cv
+        cart_vel = np.zeros(3)
+        angular_vel = np.zeros(3)
+        secondary_jacobian = None
+        secondary_vel = None
+        primary_jacobian = Jlin
+        primary_vel = cart_vel
+        mode_label = 'linear'
+
+        if self._linear_mode:
+            # Interpret the input in the configured command frame, then solve in base coordinates.
+            cart_vel = self._command_velocity_in_base(solve_q, cart_vel_cmd)
+
+            # Hold the current height unless the user is explicitly commanding Z.
+            # This keeps lateral motion from slowly climbing as the arm changes posture.
+            if self._ee_z_ref is not None and abs(cart_vel_cmd[2]) < deadzone:
+                z_error = self._ee_z_ref - float(self._get_ee_pos(solve_q)[2])
+                z_hold_vel = 2.0 * z_error
+                hold_scale = _joint_limit_hold_scale(solve_q, self._q_lo, self._q_hi)
+                # Relax the height hold near saturation so a reverse x/y command can
+                # back the arm away from the limit instead of fighting the stale z target.
+                cart_vel[2] = float(np.clip(z_hold_vel * hold_scale, -max_cv, max_cv))
+
+            if self._front_x_ref is not None and abs(cart_vel_cmd[0]) < deadzone:
+                x_error = self._front_x_ref - float(self._get_ee_pos(solve_q)[0])
+                if x_error > 0.0:
+                    # Keep lateral motion on the front side of the workspace unless the
+                    # operator is explicitly commanding X.
+                    cart_vel[0] = float(np.clip(2.0 * x_error, 0.0, max_cv))
+
+            primary_jacobian = Jlin
+            primary_vel = cart_vel
+            current_rotation = self._get_ee_rotation(solve_q)
+            if current_rotation is not None:
+                hold_gain = (
+                    self.get_parameter('orientation_hold_gain').get_parameter_value().double_value
+                )
+                orientation_task_weight = (
+                    self.get_parameter('orientation_task_weight')
+                    .get_parameter_value()
+                    .double_value
+                )
+                angular_vel = _clip_vector(
+                    hold_gain
+                    * _rotation_error_vector(
+                        current_rotation=current_rotation,
+                        desired_rotation=self._forward_rotation,
+                    ),
+                    max_av,
+                )
+                if orientation_task_weight > 0.0:
+                    primary_jacobian = np.vstack(
+                        [Jlin, orientation_task_weight * J[3:6, :active_dofs]]
+                    )
+                    primary_vel = np.concatenate(
+                        [cart_vel, orientation_task_weight * angular_vel]
+                    )
+        else:
+            mode_label = 'rotation'
+            if self._fk_solver is None:
+                self.get_logger().warn(
+                    'Rotation mode requires KDL; holding joint position instead.',
+                    throttle_duration_sec=5.0,
+                )
+                self._publish_velocity([0.0] * self.N_JOINTS)
+                return
+
+            if self._ee_pos_ref is None:
+                self._ee_pos_ref = self._get_ee_pos(solve_q).copy()
+            pos_gain = self.get_parameter('position_hold_gain').get_parameter_value().double_value
+            position_error = self._ee_pos_ref - self._get_ee_pos(solve_q)
+            cart_vel = _clip_vector(pos_gain * position_error, max_cv)
+            angular_vel = _rotation_mode_angular_velocity(self._cmd_vel, max_av)
+            primary_jacobian = Jlin
+            primary_vel = cart_vel
+            secondary_jacobian = J[3:6, :active_dofs]
+            secondary_vel = angular_vel
+
+        # Damped least-squares IK on the active Cartesian task.
         try:
-            active_dofs = J.shape[1]
-            Jlin = J[:3, :active_dofs]
             joint_weights = self._joint_weights[:active_dofs]
-            dq, joints_clipped, vel_scale = _solve_task_velocity_with_limit_redistribution(
+            secondary_weight = (
+                self.get_parameter('secondary_task_weight').get_parameter_value().double_value
+            )
+            dq, joints_clipped, vel_scale = _solve_prioritized_task_velocity(
                 current_q=solve_q,
-                task_jacobian=Jlin,
-                cart_vel=cart_vel,
+                primary_jacobian=primary_jacobian,
+                primary_vel=primary_vel,
+                secondary_jacobian=secondary_jacobian,
+                secondary_vel=secondary_vel,
                 q_lo=self._q_lo,
                 q_hi=self._q_hi,
                 dt=self._dt,
                 max_joint_vel=max_jv,
                 damping=lam,
                 joint_weights=joint_weights,
+                secondary_weight=secondary_weight,
             )
         except np.linalg.LinAlgError:
             self.get_logger().warn('DLS solve failed.')
             return
 
         if (
-            self._startup_home is not None
+            self._linear_mode
+            and self._startup_home is not None
             and self._front_x_ref is not None
             and abs(cart_vel_cmd[0]) < deadzone
             and abs(cart_vel_cmd[1]) > deadzone
@@ -908,6 +1127,12 @@ class CartesianArmController(Node):
                 -0.25 * max_jv,
                 0.25 * max_jv,
             )
+            try:
+                pinv_primary = _weighted_dls_pseudoinverse(primary_jacobian, joint_weights, lam)
+                nullspace = np.eye(primary_jacobian.shape[1]) - pinv_primary @ primary_jacobian
+                branch_bias = nullspace @ branch_bias
+            except np.linalg.LinAlgError:
+                branch_bias = np.zeros_like(branch_bias)
             dq = dq + branch_bias
             dq = np.clip(dq, -max_jv, max_jv)
             dq = _clamp_joint_velocity_to_limits(solve_q, dq, self._q_lo, self._q_hi, self._dt)
@@ -934,11 +1159,13 @@ class CartesianArmController(Node):
         self._diag_ctr += 1
         if self._diag_ctr % 33 == 0:
             ee = self._get_ee_pos(self._q_cmd if self._q_cmd is not None else self._q)
-            achieved_cart = Jlin @ dq[:active_dofs]
+            achieved_task = Jlin @ dq[:active_dofs]
             self.get_logger().info(
+                f'mode={mode_label} '
                 f'cart_in={np.round(cart_vel, 3)} '
+                f'angular_in={np.round(angular_vel, 3)} '
                 f'dq={np.round(dq, 3)} '
-                f'cart_out={np.round(achieved_cart, 3)} '
+                f'linear_out={np.round(achieved_task, 3)} '
                 f'vel_scale={vel_scale:.2f} '
                 f'clipped={joints_clipped} '
                 f'vel_subs={self._vel_pub.get_subscription_count()} '
@@ -1088,6 +1315,7 @@ class CartesianArmController(Node):
         self._idle_hold_armed = True
         self._cmd_vel = np.zeros(3)
         self._ee_z_ref = None
+        self._ee_pos_ref = None
         if self._command_mode == 'velocity':
             self._home_active = True
             res.success = True
@@ -1103,8 +1331,14 @@ class CartesianArmController(Node):
 
     def _srv_switch_vel(self, req: SetBool.Request, res: SetBool.Response) -> SetBool.Response:
         self._linear_mode = req.data
+        self._ee_z_ref = None
+        if req.data:
+            self._ee_pos_ref = None
+        elif self._q is not None:
+            current_q = self._q_continuous if self._q_continuous is not None else self._q
+            self._ee_pos_ref = self._get_ee_pos(current_q).copy()
         res.success = True
-        res.message = 'Velocity -> LINEAR' if req.data else 'Velocity -> ANGULAR'
+        res.message = 'End-effector mode -> LINEAR' if req.data else 'End-effector mode -> ROTATION'
         self.get_logger().info(res.message)
         return res
 

--- a/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
+++ b/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
@@ -1925,54 +1925,59 @@ class CartesianArmController(Node):
                 self.get_parameter('secondary_task_weight').get_parameter_value().double_value
             )
             if not self._linear_mode and active_dofs >= 6:
-                # Rotation mode: solve ONLY with the 3×3 wrist sub-Jacobian so
-                # that q0/q1/q2 are structurally excluded and never move.
+                # Rotation mode: ONLY move wrist joints [q3, q4, q5].
+                # q0/q1/q2 are structurally excluded — the 3×3 wrist Jacobian
+                # has no column for them.
+                #
+                # Use the full 3×3 DLS so that pan commands correctly use q3+q5
+                # together (they cancel roll while adding yaw). Narrow q4's
+                # effective limits to stay away from the asymmetric lower bound
+                # (-0.46 rad) so the solver never redistributes q4 away during pan,
+                # which was what broke reversing in the previous attempt.
                 wrist_jacobian = J[3:6, 3:6]
                 wrist_weights = self._joint_weights[3:6]
                 wrist_mid = (self._q_lo[3:6] + self._q_hi[3:6]) / 2.0
                 cmd_norm = float(np.linalg.norm(primary_vel))
                 dq = np.zeros(active_dofs)
+
                 if cmd_norm < 0.05:
-                    # Joystick idle: recenter wrist joints toward their midpoints
-                    # so the next command in either direction has full range.
+                    # Joystick idle: recenter wrist joints.
                     center_vel = 0.3 * (wrist_mid - solve_q[3:6])
                     center_vel = np.clip(center_vel, -max_jv, max_jv)
                     dq[3:6] = center_vel
                     joints_clipped = []
                     vel_scale = 1.0
                 else:
-                    # Active rotation command: solve wrist-only.
-                    # Blend in a gentle centering bias on q3/q5 so they don't
-                    # accumulate at limits across repeated pan commands.
-                    # The centering bias scales down to zero near the midpoint.
-                    center_gain = 0.15
-                    center_bias = center_gain * (wrist_mid - solve_q[3:6])
-                    # Only apply centering on q3 and q5 (the ±π wrap joints).
-                    # q4 (wrist_pitch) is asymmetric and naturally stays bounded.
-                    center_vel_full = np.zeros(3)
-                    center_vel_full[0] = center_bias[0]  # q3
-                    center_vel_full[2] = center_bias[2]  # q5
-                    # Modified cart_vel = commanded + centering projected through J.
-                    # Instead of modifying cart_vel (which would corrupt the angular
-                    # command), inject centering directly into dq after the solve.
+                    # Give q4 a large weight so the DLS solver strongly avoids
+                    # using it for pan/roll commands. At any arm pose, q4's tilt
+                    # axis (angular-Y) contribution is dominant, but in non-home
+                    # configurations it also develops small angular-X/Z coupling.
+                    # The high weight routes that coupling away to q3/q5 instead.
+                    # q4 still moves freely for pure tilt commands — the DLS solution
+                    # for a singular axis is weight-independent.
+                    q4_weight = 30.0
+                    wrist_weights_rot = wrist_weights.copy()
+                    wrist_weights_rot[1] *= q4_weight
+
+                    # Buffer both q4 limits by 0.2 rad so the redistributor never
+                    # removes q4 during normal pan/tilt, only at true extremes.
+                    q4_buf = 0.2
+                    q_lo_rot = self._q_lo[3:6].copy()
+                    q_hi_rot = self._q_hi[3:6].copy()
+                    q_lo_rot[1] = self._q_lo[4] + q4_buf
+                    q_hi_rot[1] = self._q_hi[4] - q4_buf
+
                     dq_wrist, joints_clipped, vel_scale = _solve_task_velocity_with_limit_redistribution(
                         current_q=solve_q[3:6],
                         task_jacobian=wrist_jacobian,
                         cart_vel=primary_vel,
-                        q_lo=self._q_lo[3:6],
-                        q_hi=self._q_hi[3:6],
+                        q_lo=q_lo_rot,
+                        q_hi=q_hi_rot,
                         dt=self._dt,
                         max_joint_vel=max_jv,
                         damping=lam,
-                        joint_weights=wrist_weights,
+                        joint_weights=wrist_weights_rot,
                     )
-                    # Add centering bias in the nullspace of the 3×3 wrist Jacobian.
-                    # The 3×3 wrist Jacobian is square (no nullspace), so we use
-                    # a weighted addition that diminishes with command magnitude.
-                    # At full stick the bias is negligible; near zero it ramps up.
-                    bias_scale = float(np.clip(1.0 - cmd_norm / 0.8, 0.0, 1.0))
-                    dq_wrist = dq_wrist + bias_scale * center_vel_full
-                    dq_wrist = np.clip(dq_wrist, -max_jv, max_jv)
                     dq[3:6] = dq_wrist
             else:
                 dq, joints_clipped, vel_scale = _solve_prioritized_task_velocity(

--- a/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
+++ b/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
@@ -222,13 +222,35 @@ def _forward_axis_error_vector(
     return np.cross(current_forward, desired_forward)
 
 
-def _rotation_mode_angular_velocity(cmd_vel: np.ndarray, max_angular_vel: float) -> np.ndarray:
-    """Map scaler arm input to robot-frame roll, tilt, and pan angular velocity."""
+def _dominant_rotation_input(cmd_vel: np.ndarray, deadzone: float) -> np.ndarray:
+    """Keep full-stick rotation commands on one tool axis."""
+    filtered = np.array(cmd_vel, dtype=float, copy=True)
+    if deadzone <= 0.0:
+        return filtered
+
+    magnitudes = np.abs(filtered)
+    dominant = int(np.argmax(magnitudes))
+    dominant_mag = float(magnitudes[dominant])
+    if dominant_mag <= deadzone:
+        return np.zeros_like(filtered)
+
+    cross_axis_limit = max(deadzone, 0.35 * dominant_mag)
+    filtered[magnitudes < cross_axis_limit] = 0.0
+    return filtered
+
+
+def _rotation_mode_angular_velocity(
+    cmd_vel: np.ndarray,
+    max_angular_vel: float,
+    deadzone: float = 0.0,
+) -> np.ndarray:
+    """Map scaler arm input to tool-frame roll, tilt, and pan angular velocity."""
+    filtered_cmd = _dominant_rotation_input(cmd_vel, deadzone)
     return max_angular_vel * np.array(
         [
-            cmd_vel[0],  # roll around robot/tool-forward X
-            cmd_vel[2],  # tilt around robot Y
-            cmd_vel[1],  # pan/yaw around robot Z
+            filtered_cmd[0],  # forward/back stick rolls around tool X
+            filtered_cmd[2],  # Z control tilts around tool Y
+            filtered_cmd[1],  # left/right stick pans around tool Z
         ],
         dtype=float,
     )
@@ -439,6 +461,29 @@ def _remove_task_space_velocity(
     return dq - correction
 
 
+def _limit_task_space_velocity(
+    dq: np.ndarray,
+    task_jacobian: np.ndarray,
+    max_task_speed: float,
+    joint_weights: np.ndarray,
+    damping: float,
+) -> np.ndarray:
+    """Limit uncommanded task-space drift while preserving as much dq as possible."""
+    task_vel = task_jacobian @ dq
+    speed = float(np.linalg.norm(task_vel))
+    if speed <= max_task_speed or speed < 1e-9:
+        return dq
+
+    allowed_vel = task_vel * (max_task_speed / speed)
+    correction = _solve_weighted_dls_task_velocity(
+        task_jacobian=task_jacobian,
+        cart_vel=task_vel - allowed_vel,
+        joint_weights=joint_weights,
+        damping=damping,
+    )
+    return dq - correction
+
+
 def _joint_limit_hold_scale(
     current_q: np.ndarray,
     q_lo: np.ndarray,
@@ -498,13 +543,13 @@ def _linear_startup_escape_velocity(
         return escape
 
     strength = float(np.clip((margin - elbow_distance) / margin, 0.0, 1.0))
-    escape[0] = -0.35 * max_joint_vel * strength
-    escape[2] = 0.75 * max_joint_vel * strength
+    escape[0] = 0.20 * max_joint_vel * strength
+    escape[2] = 0.95 * max_joint_vel * strength
 
     wrist_room = float(current_q[4] - q_lo[4])
     if wrist_room > 0.0:
         wrist_scale = float(np.clip(wrist_room / wrist_margin, 0.0, 1.0))
-        escape[4] = -0.45 * max_joint_vel * strength * wrist_scale
+        escape[4] = -0.15 * max_joint_vel * strength * wrist_scale
     return escape
 
 
@@ -534,6 +579,41 @@ def _dominant_z_lift_velocity(
     if lifted[2] > 0.0:
         lifted[2] = min(max_cartesian_vel, max(lifted[2], min_z_speed))
     return lifted
+
+
+def _linear_lateral_forward_velocity(
+    cart_vel: np.ndarray,
+    cart_vel_cmd: np.ndarray,
+    max_cartesian_vel: float,
+    deadzone: float,
+    front_branch_gain: float,
+) -> np.ndarray:
+    """Bias pure left/right linear commands onto the forward arm branch."""
+    biased = np.array(cart_vel, dtype=float, copy=True)
+    lateral_cmd = abs(float(cart_vel_cmd[1]))
+    explicit_x_cmd = abs(float(cart_vel_cmd[0])) > deadzone
+    if (
+        explicit_x_cmd
+        or lateral_cmd <= deadzone
+        or _is_dominant_z_command(cart_vel_cmd, deadzone)
+    ):
+        return biased
+
+    forward_bias = max(
+        abs(front_branch_gain) * max_cartesian_vel,
+        0.25 * lateral_cmd,
+    )
+    forward_bias = min(forward_bias, 0.45 * max_cartesian_vel)
+    biased[0] = max(float(biased[0]), forward_bias)
+    return biased
+
+
+def _is_lateral_forward_bias_active(cart_vel_cmd: np.ndarray, deadzone: float) -> bool:
+    return (
+        abs(float(cart_vel_cmd[1])) > deadzone
+        and abs(float(cart_vel_cmd[0])) <= deadzone
+        and not _is_dominant_z_command(cart_vel_cmd, deadzone)
+    )
 
 
 def _is_dominant_positive_z_command(cart_vel_cmd: np.ndarray, deadzone: float) -> bool:
@@ -589,7 +669,7 @@ class CartesianArmController(Node):
     joint_weights          float[]  joint weighting for the IK solve
     robot_forward_rpy      float[] fixed tool orientation for "camera forward"
     orientation_hold_gain  float  proportional gain for forward orientation hold
-    orientation_task_weight float weight for linear-mode orientation hold
+    orientation_task_weight float nullspace weight for linear-mode orientation hold
     linear_posture_target  float[] nullspace posture target for linear mode
     linear_posture_weight  float  weight for linear-mode posture task
     linear_posture_gain    float  proportional gain for linear posture task
@@ -644,8 +724,8 @@ class CartesianArmController(Node):
         self.declare_parameter('idle_hold_tolerance', 0.01)
         self.declare_parameter('front_branch_gain', 0.05)
         self.declare_parameter('robot_forward_rpy', [0.0, 0.0, 0.0])
-        self.declare_parameter('orientation_hold_gain', 1.0)
-        self.declare_parameter('orientation_task_weight', 0.8)
+        self.declare_parameter('orientation_hold_gain', 2.0)
+        self.declare_parameter('orientation_task_weight', 1.4)
         self.declare_parameter('linear_posture_target', self.HOME_POSITION)
         self.declare_parameter('linear_posture_weight', 0.2)
         self.declare_parameter('linear_posture_gain', 0.25)
@@ -1161,6 +1241,7 @@ class CartesianArmController(Node):
         primary_jacobian = Jlin
         primary_vel = cart_vel
         mode_label = 'linear'
+        startup_unfold_primary = False
 
         if self._linear_mode:
             # Interpret the input in the configured command frame, then solve in base coordinates.
@@ -1172,6 +1253,13 @@ class CartesianArmController(Node):
                 max_cartesian_vel=max_cv,
                 cart_vel_cmd=cart_vel_cmd,
                 deadzone=deadzone,
+            )
+            cart_vel = _linear_lateral_forward_velocity(
+                cart_vel=cart_vel,
+                cart_vel_cmd=cart_vel_cmd,
+                max_cartesian_vel=max_cv,
+                deadzone=deadzone,
+                front_branch_gain=self._front_branch_gain,
             )
 
             # Hold the current height unless the user is explicitly commanding Z.
@@ -1194,7 +1282,8 @@ class CartesianArmController(Node):
             primary_jacobian = linear_task_jacobian
             primary_vel = linear_task_vel
             current_rotation = self._get_ee_rotation(solve_q)
-            if current_rotation is not None:
+            hold_orientation = not _is_dominant_z_command(cart_vel_cmd, deadzone)
+            if current_rotation is not None and hold_orientation:
                 hold_gain = (
                     self.get_parameter('orientation_hold_gain').get_parameter_value().double_value
                 )
@@ -1233,7 +1322,7 @@ class CartesianArmController(Node):
                     secondary_vel=secondary_vel,
                     task_jacobian=np.eye(active_dofs),
                     task_vel=startup_escape_vel,
-                    weight=1.0,
+                    weight=0.8,
                 )
 
             posture_weight = (
@@ -1264,7 +1353,16 @@ class CartesianArmController(Node):
                 return
 
             cart_vel = np.zeros(3)
-            angular_vel = _rotation_mode_angular_velocity(self._cmd_vel, max_av)
+            tool_angular_vel = _rotation_mode_angular_velocity(
+                self._cmd_vel,
+                max_av,
+                deadzone=deadzone,
+            )
+            current_rotation = self._get_ee_rotation(solve_q)
+            if current_rotation is None:
+                angular_vel = tool_angular_vel
+            else:
+                angular_vel = current_rotation @ tool_angular_vel
             primary_jacobian = Jlin
             primary_vel = cart_vel
             secondary_jacobian, secondary_vel = _append_secondary_task(
@@ -1341,7 +1439,32 @@ class CartesianArmController(Node):
                 self._dt,
             )
 
-        if self._linear_mode and _is_dominant_z_command(cart_vel_cmd, deadzone):
+        if (
+            self._linear_mode
+            and not startup_unfold_primary
+            and _is_dominant_z_command(cart_vel_cmd, deadzone)
+        ):
+            max_xy_leak = max(0.04, 0.15 * abs(float(cart_vel[2])))
+            dq = _limit_task_space_velocity(
+                dq=dq[:active_dofs],
+                task_jacobian=Jlin[0:2, :],
+                max_task_speed=max_xy_leak,
+                joint_weights=joint_weights,
+                damping=min(lam, 1e-4),
+            )
+            dq = _clamp_joint_velocity_to_limits(
+                solve_q[:active_dofs],
+                dq,
+                self._q_lo[:active_dofs],
+                self._q_hi[:active_dofs],
+                self._dt,
+            )
+
+        if (
+            self._linear_mode
+            and not startup_unfold_primary
+            and _is_dominant_z_command(cart_vel_cmd, deadzone)
+        ):
             z_jacobian = Jlin[2:3, :]
             desired_z_vel = float(cart_vel[2])
             achieved_z_vel = float((z_jacobian @ dq[:active_dofs])[0])
@@ -1386,7 +1509,57 @@ class CartesianArmController(Node):
                     dq = np.zeros_like(dq)
                     joints_clipped = [*joints_clipped, 'Z↕blocked']
 
-        if self._linear_mode and _is_dominant_positive_z_command(cart_vel_cmd, deadzone):
+        if (
+            self._linear_mode
+            and not startup_unfold_primary
+            and _is_lateral_forward_bias_active(cart_vel_cmd, deadzone)
+        ):
+            x_jacobian = Jlin[0:1, :]
+            desired_x_vel = max(float(cart_vel[0]), 0.0)
+            achieved_x_vel = float((x_jacobian @ dq[:active_dofs])[0])
+            x_error = achieved_x_vel - desired_x_vel
+            if x_error < -1e-4:
+                x_correction = _solve_weighted_dls_task_velocity(
+                    task_jacobian=x_jacobian,
+                    cart_vel=np.array([x_error]),
+                    joint_weights=joint_weights,
+                    damping=min(lam, 1e-4),
+                )
+                dq = _clamp_joint_velocity_to_limits(
+                    solve_q[:active_dofs],
+                    dq[:active_dofs] - x_correction,
+                    self._q_lo[:active_dofs],
+                    self._q_hi[:active_dofs],
+                    self._dt,
+                )
+                achieved_x_vel = float((x_jacobian @ dq[:active_dofs])[0])
+
+            if desired_x_vel > deadzone and achieved_x_vel <= 0.0:
+                x_only_dq, x_only_clipped, x_only_scale = _solve_task_velocity_with_limit_redistribution(
+                    current_q=solve_q[:active_dofs],
+                    task_jacobian=x_jacobian,
+                    cart_vel=np.array([desired_x_vel]),
+                    q_lo=self._q_lo[:active_dofs],
+                    q_hi=self._q_hi[:active_dofs],
+                    dt=self._dt,
+                    max_joint_vel=max_jv,
+                    damping=lam,
+                    joint_weights=joint_weights,
+                )
+                x_only_vel = float((x_jacobian @ x_only_dq[:active_dofs])[0])
+                if x_only_vel > 0.0:
+                    dq = x_only_dq
+                    joints_clipped = [*joints_clipped, *x_only_clipped, 'X→guard']
+                    vel_scale = min(vel_scale, x_only_scale)
+                else:
+                    dq = np.zeros_like(dq)
+                    joints_clipped = [*joints_clipped, 'X→blocked']
+
+        if (
+            self._linear_mode
+            and not startup_unfold_primary
+            and _is_dominant_positive_z_command(cart_vel_cmd, deadzone)
+        ):
             current_z = float(self._get_ee_pos(solve_q)[2])
             next_q = np.clip(solve_q + dq * self._dt, self._q_lo, self._q_hi)
             next_z = float(self._get_ee_pos(next_q)[2])

--- a/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
+++ b/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
@@ -1878,7 +1878,7 @@ class CartesianArmController(Node):
                 # (cross(camera_forward, world_Z)) so that up/down commands tilt the
                 # camera up/down regardless of current arm pose.
                 world_z = np.array([0.0, 0.0, 1.0])
-                tilt_axis_raw = np.cross(roll_axis, world_z)
+                tilt_axis_raw = np.cross(world_z, roll_axis)
                 tilt_norm = np.linalg.norm(tilt_axis_raw)
                 tilt_axis = tilt_axis_raw / tilt_norm if tilt_norm > 0.1 else current_rotation[:, 1]
                 # Yaw/pan: always around base-frame vertical Z.

--- a/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
+++ b/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
@@ -301,7 +301,7 @@ def _rotation_mode_angular_velocity(
     return max_angular_vel * np.array(
         [
             filtered_cmd[0],  # forward/back stick rolls around tool X
-            filtered_cmd[2],  # Z control tilts around tool Y
+            -filtered_cmd[2],  # Z control tilts around tool Y (negated for correct up/down direction)
             filtered_cmd[1],  # left/right stick pans around tool Z
         ],
         dtype=float,

--- a/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
+++ b/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
@@ -206,6 +206,22 @@ def _rotation_error_vector(current_rotation: np.ndarray, desired_rotation: np.nd
     return (theta / (2.0 * sin_theta)) * skew_vec
 
 
+def _forward_axis_error_vector(
+    current_rotation: np.ndarray,
+    desired_rotation: np.ndarray,
+) -> np.ndarray:
+    """Return angular correction that points the tool forward axis at robot-forward."""
+    current_forward = current_rotation[:, 0]
+    desired_forward = desired_rotation[:, 0]
+    current_norm = np.linalg.norm(current_forward)
+    desired_norm = np.linalg.norm(desired_forward)
+    if current_norm < 1e-9 or desired_norm < 1e-9:
+        return np.zeros(3)
+    current_forward = current_forward / current_norm
+    desired_forward = desired_forward / desired_norm
+    return np.cross(current_forward, desired_forward)
+
+
 def _rotation_mode_angular_velocity(cmd_vel: np.ndarray, max_angular_vel: float) -> np.ndarray:
     """Map scaler arm input to robot-frame roll, tilt, and pan angular velocity."""
     return max_angular_vel * np.array(
@@ -256,6 +272,27 @@ def _weighted_dls_pseudoinverse(
     )
 
 
+def _append_secondary_task(
+    secondary_jacobian: np.ndarray | None,
+    secondary_vel: np.ndarray | None,
+    task_jacobian: np.ndarray,
+    task_vel: np.ndarray,
+    weight: float,
+) -> tuple[np.ndarray | None, np.ndarray | None]:
+    """Append a weighted secondary task, preserving an empty task as None."""
+    if weight <= 0.0 or task_jacobian.size == 0 or task_vel.size == 0:
+        return secondary_jacobian, secondary_vel
+
+    weighted_jacobian = weight * task_jacobian
+    weighted_vel = weight * task_vel
+    if secondary_jacobian is None or secondary_vel is None:
+        return weighted_jacobian, weighted_vel
+    return (
+        np.vstack([secondary_jacobian, weighted_jacobian]),
+        np.concatenate([secondary_vel, weighted_vel]),
+    )
+
+
 def _solve_task_velocity_with_limit_redistribution(
     current_q: np.ndarray,
     task_jacobian: np.ndarray,
@@ -294,12 +331,6 @@ def _solve_task_velocity_with_limit_redistribution(
 
         dq_candidate = np.zeros(n_joints)
         dq_candidate[active_indices] = dq_active
-        dq_candidate += _joint_limit_recovery_velocity(
-            current_q=current_q,
-            q_lo=q_lo,
-            q_hi=q_hi,
-            max_joint_vel=max_joint_vel,
-        )
 
         peak = float(np.max(np.abs(dq_active)))
         vel_scale = 1.0
@@ -374,15 +405,38 @@ def _solve_prioritized_task_velocity(
         joint_weights=joint_weights,
         damping=damping,
     )
+    remaining_budget = np.maximum(max_joint_vel - np.abs(dq), 0.0)
+    secondary_scale = 1.0
+    for idx, value in enumerate(dq_secondary):
+        magnitude = abs(float(value))
+        if magnitude > 1e-12:
+            secondary_scale = min(secondary_scale, remaining_budget[idx] / magnitude)
+    dq_secondary *= float(np.clip(secondary_scale, 0.0, 1.0))
+
     dq_candidate = dq + dq_secondary
-    peak = float(np.max(np.abs(dq_candidate)))
-    if peak > max_joint_vel:
-        vel_scale = min(vel_scale, max_joint_vel / peak)
-        dq_candidate *= max_joint_vel / peak
     dq_candidate = _clamp_joint_velocity_to_limits(
         current_q, dq_candidate, q_lo, q_hi, dt
     )
     return dq_candidate, joints_clipped, vel_scale
+
+
+def _remove_task_space_velocity(
+    dq: np.ndarray,
+    task_jacobian: np.ndarray,
+    joint_weights: np.ndarray,
+    damping: float,
+) -> np.ndarray:
+    """Project a command back onto the zero-velocity manifold for a task."""
+    residual = task_jacobian @ dq
+    if np.linalg.norm(residual) < 1e-9:
+        return dq
+    correction = _solve_weighted_dls_task_velocity(
+        task_jacobian=task_jacobian,
+        cart_vel=residual,
+        joint_weights=joint_weights,
+        damping=damping,
+    )
+    return dq - correction
 
 
 def _joint_limit_hold_scale(
@@ -420,6 +474,78 @@ def _joint_limit_recovery_velocity(
     recovery = np.clip((center - current_q) / limit_margin, -1.0, 1.0)
     recovery *= proximity * recovery_gain * max_joint_vel
     return recovery
+
+
+def _linear_startup_escape_velocity(
+    current_q: np.ndarray,
+    q_lo: np.ndarray,
+    max_joint_vel: float,
+    cart_vel_cmd: np.ndarray,
+    deadzone: float,
+    margin: float = 0.25,
+    wrist_margin: float = 0.08,
+) -> np.ndarray:
+    """Bias folded startup Z motion toward an arm shape that can actually rise."""
+    escape = np.zeros_like(current_q)
+    if len(current_q) < 5:
+        return escape
+
+    if not _is_dominant_positive_z_command(cart_vel_cmd, deadzone):
+        return escape
+
+    elbow_distance = float(current_q[2] - q_lo[2])
+    if elbow_distance >= margin:
+        return escape
+
+    strength = float(np.clip((margin - elbow_distance) / margin, 0.0, 1.0))
+    escape[0] = -0.35 * max_joint_vel * strength
+    escape[2] = 0.75 * max_joint_vel * strength
+
+    wrist_room = float(current_q[4] - q_lo[4])
+    if wrist_room > 0.0:
+        wrist_scale = float(np.clip(wrist_room / wrist_margin, 0.0, 1.0))
+        escape[4] = -0.45 * max_joint_vel * strength * wrist_scale
+    return escape
+
+
+def _dominant_z_lift_velocity(
+    cart_vel: np.ndarray,
+    current_q: np.ndarray,
+    q_lo: np.ndarray,
+    max_cartesian_vel: float,
+    cart_vel_cmd: np.ndarray,
+    deadzone: float,
+    elbow_margin: float = 0.35,
+    shoulder_unfolded: float = 0.75,
+) -> np.ndarray:
+    """Boost folded positive-Z lift without injecting forward motion."""
+    lifted = np.array(cart_vel, dtype=float, copy=True)
+    if len(current_q) < 3 or not _is_dominant_positive_z_command(cart_vel_cmd, deadzone):
+        return lifted
+
+    elbow_distance = float(current_q[2] - q_lo[2])
+    elbow_fold = float(np.clip((elbow_margin - elbow_distance) / elbow_margin, 0.0, 1.0))
+    shoulder_fold = float(np.clip((shoulder_unfolded - current_q[0]) / shoulder_unfolded, 0.0, 1.0))
+    strength = max(elbow_fold, shoulder_fold)
+    if strength <= 0.0:
+        return lifted
+
+    min_z_speed = 0.75 * max_cartesian_vel * strength
+    if lifted[2] > 0.0:
+        lifted[2] = min(max_cartesian_vel, max(lifted[2], min_z_speed))
+    return lifted
+
+
+def _is_dominant_positive_z_command(cart_vel_cmd: np.ndarray, deadzone: float) -> bool:
+    z_cmd = float(cart_vel_cmd[2])
+    lateral_cmd = float(max(abs(cart_vel_cmd[0]), abs(cart_vel_cmd[1])))
+    return z_cmd > deadzone and z_cmd >= lateral_cmd
+
+
+def _is_dominant_z_command(cart_vel_cmd: np.ndarray, deadzone: float) -> bool:
+    z_cmd = abs(float(cart_vel_cmd[2]))
+    lateral_cmd = float(max(abs(cart_vel_cmd[0]), abs(cart_vel_cmd[1])))
+    return z_cmd > deadzone and z_cmd >= lateral_cmd
 
 
 class CartesianArmController(Node):
@@ -464,6 +590,9 @@ class CartesianArmController(Node):
     robot_forward_rpy      float[] fixed tool orientation for "camera forward"
     orientation_hold_gain  float  proportional gain for forward orientation hold
     orientation_task_weight float weight for linear-mode orientation hold
+    linear_posture_target  float[] nullspace posture target for linear mode
+    linear_posture_weight  float  weight for linear-mode posture task
+    linear_posture_gain    float  proportional gain for linear posture task
     position_hold_gain     float  proportional gain for rotation-mode position hold
     secondary_task_weight  float  weight for nullspace angular task
     """
@@ -517,6 +646,9 @@ class CartesianArmController(Node):
         self.declare_parameter('robot_forward_rpy', [0.0, 0.0, 0.0])
         self.declare_parameter('orientation_hold_gain', 1.0)
         self.declare_parameter('orientation_task_weight', 0.8)
+        self.declare_parameter('linear_posture_target', self.HOME_POSITION)
+        self.declare_parameter('linear_posture_weight', 0.2)
+        self.declare_parameter('linear_posture_gain', 0.25)
         self.declare_parameter('position_hold_gain', 2.0)
         self.declare_parameter('secondary_task_weight', 1.0)
 
@@ -534,6 +666,18 @@ class CartesianArmController(Node):
         self._front_branch_gain = (
             self.get_parameter('front_branch_gain').get_parameter_value().double_value
         )
+        linear_posture_target = list(self.get_parameter('linear_posture_target').value)
+        if len(linear_posture_target) != self.N_JOINTS:
+            self.get_logger().warn(
+                'linear_posture_target must have 6 values; using HOME_POSITION.'
+            )
+            linear_posture_target = self.HOME_POSITION
+        self._linear_posture_target = np.array(linear_posture_target, dtype=float)
+        if not np.all(np.isfinite(self._linear_posture_target)):
+            self.get_logger().warn(
+                'linear_posture_target contains non-finite values; using HOME_POSITION.'
+            )
+            self._linear_posture_target = np.array(self.HOME_POSITION, dtype=float)
         forward_rpy = list(self.get_parameter('robot_forward_rpy').value)
         if len(forward_rpy) != 3:
             self.get_logger().warn('robot_forward_rpy must have 3 values; using [0, 0, 0].')
@@ -1021,6 +1165,14 @@ class CartesianArmController(Node):
         if self._linear_mode:
             # Interpret the input in the configured command frame, then solve in base coordinates.
             cart_vel = self._command_velocity_in_base(solve_q, cart_vel_cmd)
+            cart_vel = _dominant_z_lift_velocity(
+                cart_vel=cart_vel,
+                current_q=solve_q,
+                q_lo=self._q_lo,
+                max_cartesian_vel=max_cv,
+                cart_vel_cmd=cart_vel_cmd,
+                deadzone=deadzone,
+            )
 
             # Hold the current height unless the user is explicitly commanding Z.
             # This keeps lateral motion from slowly climbing as the arm changes posture.
@@ -1032,15 +1184,15 @@ class CartesianArmController(Node):
                 # back the arm away from the limit instead of fighting the stale z target.
                 cart_vel[2] = float(np.clip(z_hold_vel * hold_scale, -max_cv, max_cv))
 
-            if self._front_x_ref is not None and abs(cart_vel_cmd[0]) < deadzone:
-                x_error = self._front_x_ref - float(self._get_ee_pos(solve_q)[0])
-                if x_error > 0.0:
-                    # Keep lateral motion on the front side of the workspace unless the
-                    # operator is explicitly commanding X.
-                    cart_vel[0] = float(np.clip(2.0 * x_error, 0.0, max_cv))
+            if _is_dominant_z_command(cart_vel_cmd, deadzone):
+                linear_task_jacobian = Jlin[2:3, :]
+                linear_task_vel = np.array([cart_vel[2]])
+            else:
+                linear_task_jacobian = Jlin
+                linear_task_vel = cart_vel
 
-            primary_jacobian = Jlin
-            primary_vel = cart_vel
+            primary_jacobian = linear_task_jacobian
+            primary_vel = linear_task_vel
             current_rotation = self._get_ee_rotation(solve_q)
             if current_rotation is not None:
                 hold_gain = (
@@ -1053,19 +1205,54 @@ class CartesianArmController(Node):
                 )
                 angular_vel = _clip_vector(
                     hold_gain
-                    * _rotation_error_vector(
+                    * _forward_axis_error_vector(
                         current_rotation=current_rotation,
                         desired_rotation=self._forward_rotation,
                     ),
                     max_av,
                 )
                 if orientation_task_weight > 0.0:
-                    primary_jacobian = np.vstack(
-                        [Jlin, orientation_task_weight * J[3:6, :active_dofs]]
+                    secondary_jacobian, secondary_vel = _append_secondary_task(
+                        secondary_jacobian=secondary_jacobian,
+                        secondary_vel=secondary_vel,
+                        task_jacobian=J[3:6, :active_dofs],
+                        task_vel=angular_vel,
+                        weight=orientation_task_weight,
                     )
-                    primary_vel = np.concatenate(
-                        [cart_vel, orientation_task_weight * angular_vel]
-                    )
+
+            startup_escape_vel = _linear_startup_escape_velocity(
+                current_q=solve_q[:active_dofs],
+                q_lo=self._q_lo[:active_dofs],
+                max_joint_vel=max_jv,
+                cart_vel_cmd=cart_vel_cmd,
+                deadzone=deadzone,
+            )
+            if np.linalg.norm(startup_escape_vel) > 1e-9:
+                secondary_jacobian, secondary_vel = _append_secondary_task(
+                    secondary_jacobian=secondary_jacobian,
+                    secondary_vel=secondary_vel,
+                    task_jacobian=np.eye(active_dofs),
+                    task_vel=startup_escape_vel,
+                    weight=1.0,
+                )
+
+            posture_weight = (
+                self.get_parameter('linear_posture_weight').get_parameter_value().double_value
+            )
+            posture_gain = (
+                self.get_parameter('linear_posture_gain').get_parameter_value().double_value
+            )
+            posture_vel = _clip_vector(
+                posture_gain * (self._linear_posture_target[:active_dofs] - solve_q[:active_dofs]),
+                0.35 * max_jv,
+            )
+            secondary_jacobian, secondary_vel = _append_secondary_task(
+                secondary_jacobian=secondary_jacobian,
+                secondary_vel=secondary_vel,
+                task_jacobian=np.eye(active_dofs),
+                task_vel=posture_vel,
+                weight=posture_weight,
+            )
         else:
             mode_label = 'rotation'
             if self._fk_solver is None:
@@ -1076,16 +1263,31 @@ class CartesianArmController(Node):
                 self._publish_velocity([0.0] * self.N_JOINTS)
                 return
 
-            if self._ee_pos_ref is None:
-                self._ee_pos_ref = self._get_ee_pos(solve_q).copy()
-            pos_gain = self.get_parameter('position_hold_gain').get_parameter_value().double_value
-            position_error = self._ee_pos_ref - self._get_ee_pos(solve_q)
-            cart_vel = _clip_vector(pos_gain * position_error, max_cv)
+            cart_vel = np.zeros(3)
             angular_vel = _rotation_mode_angular_velocity(self._cmd_vel, max_av)
             primary_jacobian = Jlin
             primary_vel = cart_vel
-            secondary_jacobian = J[3:6, :active_dofs]
-            secondary_vel = angular_vel
+            secondary_jacobian, secondary_vel = _append_secondary_task(
+                secondary_jacobian=secondary_jacobian,
+                secondary_vel=secondary_vel,
+                task_jacobian=J[3:6, :active_dofs],
+                task_vel=angular_vel,
+                weight=1.0,
+            )
+
+        limit_recovery = _joint_limit_recovery_velocity(
+            current_q=solve_q,
+            q_lo=self._q_lo,
+            q_hi=self._q_hi,
+            max_joint_vel=max_jv,
+        )
+        secondary_jacobian, secondary_vel = _append_secondary_task(
+            secondary_jacobian=secondary_jacobian,
+            secondary_vel=secondary_vel,
+            task_jacobian=np.eye(active_dofs),
+            task_vel=limit_recovery[:active_dofs],
+            weight=1.0,
+        )
 
         # Damped least-squares IK on the active Cartesian task.
         try:
@@ -1111,31 +1313,115 @@ class CartesianArmController(Node):
             self.get_logger().warn('DLS solve failed.')
             return
 
-        if (
-            self._linear_mode
-            and self._startup_home is not None
-            and self._front_x_ref is not None
-            and abs(cart_vel_cmd[0]) < deadzone
-            and abs(cart_vel_cmd[1]) > deadzone
-            and self._front_branch_gain > 0.0
-        ):
-            # Bias the nullspace toward the startup/front branch while the user is
-            # steering y. This keeps reversals from flipping to the back side without
-            # injecting a sideways pull into pure vertical motion.
-            branch_bias = np.clip(
-                self._front_branch_gain * (self._startup_home - solve_q),
-                -0.25 * max_jv,
-                0.25 * max_jv,
+        if not self._linear_mode:
+            dq = _remove_task_space_velocity(
+                dq=dq,
+                task_jacobian=Jlin,
+                joint_weights=joint_weights,
+                damping=min(lam, 1e-4),
             )
-            try:
-                pinv_primary = _weighted_dls_pseudoinverse(primary_jacobian, joint_weights, lam)
-                nullspace = np.eye(primary_jacobian.shape[1]) - pinv_primary @ primary_jacobian
-                branch_bias = nullspace @ branch_bias
-            except np.linalg.LinAlgError:
-                branch_bias = np.zeros_like(branch_bias)
-            dq = dq + branch_bias
-            dq = np.clip(dq, -max_jv, max_jv)
-            dq = _clamp_joint_velocity_to_limits(solve_q, dq, self._q_lo, self._q_hi, self._dt)
+            dq = _clamp_joint_velocity_to_limits(
+                solve_q[:active_dofs],
+                dq,
+                self._q_lo[:active_dofs],
+                self._q_hi[:active_dofs],
+                self._dt,
+            )
+            dq = _remove_task_space_velocity(
+                dq=dq,
+                task_jacobian=Jlin,
+                joint_weights=joint_weights,
+                damping=min(lam, 1e-4),
+            )
+            dq = _clamp_joint_velocity_to_limits(
+                solve_q[:active_dofs],
+                dq,
+                self._q_lo[:active_dofs],
+                self._q_hi[:active_dofs],
+                self._dt,
+            )
+
+        if self._linear_mode and _is_dominant_z_command(cart_vel_cmd, deadzone):
+            z_jacobian = Jlin[2:3, :]
+            desired_z_vel = float(cart_vel[2])
+            achieved_z_vel = float((z_jacobian @ dq[:active_dofs])[0])
+            z_error = achieved_z_vel - desired_z_vel
+            if abs(z_error) > 1e-4:
+                z_correction = _solve_weighted_dls_task_velocity(
+                    task_jacobian=z_jacobian,
+                    cart_vel=np.array([z_error]),
+                    joint_weights=joint_weights,
+                    damping=min(lam, 1e-4),
+                )
+                dq = _clamp_joint_velocity_to_limits(
+                    solve_q[:active_dofs],
+                    dq[:active_dofs] - z_correction,
+                    self._q_lo[:active_dofs],
+                    self._q_hi[:active_dofs],
+                    self._dt,
+                )
+                achieved_z_vel = float((z_jacobian @ dq[:active_dofs])[0])
+
+            if (
+                abs(desired_z_vel) > deadzone
+                and achieved_z_vel * desired_z_vel <= 0.0
+            ):
+                z_only_dq, z_only_clipped, z_only_scale = _solve_task_velocity_with_limit_redistribution(
+                    current_q=solve_q[:active_dofs],
+                    task_jacobian=z_jacobian,
+                    cart_vel=np.array([desired_z_vel]),
+                    q_lo=self._q_lo[:active_dofs],
+                    q_hi=self._q_hi[:active_dofs],
+                    dt=self._dt,
+                    max_joint_vel=max_jv,
+                    damping=lam,
+                    joint_weights=joint_weights,
+                )
+                z_only_vel = float((z_jacobian @ z_only_dq[:active_dofs])[0])
+                if z_only_vel * desired_z_vel > 0.0:
+                    dq = z_only_dq
+                    joints_clipped = [*joints_clipped, *z_only_clipped, 'Z↕guard']
+                    vel_scale = min(vel_scale, z_only_scale)
+                else:
+                    dq = np.zeros_like(dq)
+                    joints_clipped = [*joints_clipped, 'Z↕blocked']
+
+        if self._linear_mode and _is_dominant_positive_z_command(cart_vel_cmd, deadzone):
+            current_z = float(self._get_ee_pos(solve_q)[2])
+            next_q = np.clip(solve_q + dq * self._dt, self._q_lo, self._q_hi)
+            next_z = float(self._get_ee_pos(next_q)[2])
+            if next_z < current_z - 1e-4:
+                rescue_dq = _linear_startup_escape_velocity(
+                    current_q=solve_q[:active_dofs],
+                    q_lo=self._q_lo[:active_dofs],
+                    max_joint_vel=max_jv,
+                    cart_vel_cmd=cart_vel_cmd,
+                    deadzone=deadzone,
+                )
+                if np.linalg.norm(rescue_dq) > 1e-9:
+                    rescue_dq = _clamp_joint_velocity_to_limits(
+                        solve_q[:active_dofs],
+                        rescue_dq,
+                        self._q_lo[:active_dofs],
+                        self._q_hi[:active_dofs],
+                        self._dt,
+                    )
+                    rescue_next_q = solve_q.copy()
+                    rescue_next_q[:active_dofs] = np.clip(
+                        solve_q[:active_dofs] + rescue_dq * self._dt,
+                        self._q_lo[:active_dofs],
+                        self._q_hi[:active_dofs],
+                    )
+                    rescue_next_z = float(self._get_ee_pos(rescue_next_q)[2])
+                    if rescue_next_z >= current_z - 1e-4:
+                        dq = rescue_dq
+                        joints_clipped = [*joints_clipped, 'Z↑guard']
+                    else:
+                        dq = np.zeros_like(dq)
+                        joints_clipped = [*joints_clipped, 'Z↑blocked']
+                else:
+                    dq = np.zeros_like(dq)
+                    joints_clipped = [*joints_clipped, 'Z↑blocked']
 
         # In trajectory mode, generate the next target from the measured pose.
         # This keeps the published joint step consistent with the Jacobian

--- a/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
+++ b/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
@@ -1350,7 +1350,18 @@ class CartesianArmController(Node):
                     candidate_error,
                 )
 
-        if best_preserves_direction and best_error < current_error:
+        if best_preserves_direction and best_error <= current_error + 1e-3:
+            return (
+                best_dq,
+                [*best_clipped, f'forward_guard:{best_scale:.2f}'],
+                best_scale,
+                current_error,
+                best_error,
+            )
+        # No scale produced direction-preserving motion. If the orientation error
+        # is already small (below 2× tolerance), allow movement anyway — the arm
+        # is close enough to correct orientation that blocking wastes all motion.
+        if best_scale > 0.0 and current_error <= 2.0 * 0.02:
             return (
                 best_dq,
                 [*best_clipped, f'forward_guard:{best_scale:.2f}'],
@@ -1861,16 +1872,36 @@ class CartesianArmController(Node):
             if current_rotation is None:
                 angular_vel = tool_angular_vel
             else:
-                angular_vel = current_rotation @ tool_angular_vel
-            primary_jacobian = Jlin
-            primary_vel = cart_vel
-            secondary_jacobian, secondary_vel = _append_secondary_task(
-                secondary_jacobian=secondary_jacobian,
-                secondary_vel=secondary_vel,
-                task_jacobian=J[3:6, :active_dofs],
-                task_vel=angular_vel,
-                weight=1.0,
-            )
+                # Roll: always around the camera's own forward axis (tool X in base frame).
+                roll_axis = current_rotation[:, 0]
+                # Tilt: always around the horizontal axis perpendicular to camera forward
+                # (cross(camera_forward, world_Z)) so that up/down commands tilt the
+                # camera up/down regardless of current arm pose.
+                world_z = np.array([0.0, 0.0, 1.0])
+                tilt_axis_raw = np.cross(roll_axis, world_z)
+                tilt_norm = np.linalg.norm(tilt_axis_raw)
+                tilt_axis = tilt_axis_raw / tilt_norm if tilt_norm > 0.1 else current_rotation[:, 1]
+                # Yaw/pan: always around base-frame vertical Z.
+                angular_vel = (
+                    tool_angular_vel[0] * roll_axis
+                    + tool_angular_vel[1] * tilt_axis
+                    + np.array([0.0, 0.0, tool_angular_vel[2]])
+                )
+            # Angular velocity is the primary task.  The minimum-norm DLS solution
+            # naturally routes pan to q1 (base_roll), keeping the motion intuitive.
+            # Soft-stop pan when q1 approaches ±90° so the arm cannot swing to the rear.
+            q1 = float(solve_q[1]) if len(solve_q) > 1 else 0.0
+            pan_limit = np.pi / 2  # 90°
+            pan_margin = 0.15      # start fading 0.15 rad before the limit
+            pan_distance = pan_limit - abs(q1)
+            pan_scale = float(np.clip(pan_distance / pan_margin, 0.0, 1.0))
+            yaw_component = angular_vel[2]
+            if (q1 > 0 and yaw_component < 0) or (q1 < 0 and yaw_component > 0):
+                pan_scale = 1.0  # never suppress motion back toward centre
+            angular_vel = angular_vel.copy()
+            angular_vel[2] *= pan_scale
+            primary_jacobian = J[3:6, :active_dofs]
+            primary_vel = angular_vel
 
         limit_recovery = _joint_limit_recovery_velocity(
             current_q=solve_q,
@@ -1878,13 +1909,14 @@ class CartesianArmController(Node):
             q_hi=self._q_hi,
             max_joint_vel=max_jv,
         )
-        secondary_jacobian, secondary_vel = _append_secondary_task(
-            secondary_jacobian=secondary_jacobian,
-            secondary_vel=secondary_vel,
-            task_jacobian=np.eye(active_dofs),
-            task_vel=limit_recovery[:active_dofs],
-            weight=1.0,
-        )
+        if self._linear_mode:
+            secondary_jacobian, secondary_vel = _append_secondary_task(
+                secondary_jacobian=secondary_jacobian,
+                secondary_vel=secondary_vel,
+                task_jacobian=np.eye(active_dofs),
+                task_vel=limit_recovery[:active_dofs],
+                weight=1.0,
+            )
 
         # Damped least-squares IK on the active Cartesian task.
         try:
@@ -1892,51 +1924,51 @@ class CartesianArmController(Node):
             secondary_weight = (
                 self.get_parameter('secondary_task_weight').get_parameter_value().double_value
             )
-            dq, joints_clipped, vel_scale = _solve_prioritized_task_velocity(
-                current_q=solve_q,
-                primary_jacobian=primary_jacobian,
-                primary_vel=primary_vel,
-                secondary_jacobian=secondary_jacobian,
-                secondary_vel=secondary_vel,
-                q_lo=self._q_lo,
-                q_hi=self._q_hi,
-                dt=self._dt,
-                max_joint_vel=max_jv,
-                damping=lam,
-                joint_weights=joint_weights,
-                secondary_weight=secondary_weight,
-            )
+            if not self._linear_mode and active_dofs >= 6:
+                # Rotation mode: solve ONLY with the 3×3 wrist sub-Jacobian so
+                # that q0/q1/q2 (proximal joints) are structurally excluded from
+                # the solve and can never move.
+                wrist_jacobian = J[3:6, 3:6]
+                wrist_weights = self._joint_weights[3:6]
+                dq_wrist, joints_clipped, vel_scale = _solve_task_velocity_with_limit_redistribution(
+                    current_q=solve_q[3:6],
+                    task_jacobian=wrist_jacobian,
+                    cart_vel=primary_vel,
+                    q_lo=self._q_lo[3:6],
+                    q_hi=self._q_hi[3:6],
+                    dt=self._dt,
+                    max_joint_vel=max_jv,
+                    damping=lam,
+                    joint_weights=wrist_weights,
+                )
+                dq = np.zeros(active_dofs)
+                dq[3:6] = dq_wrist
+                # When joystick is idle, gently recenter wrist joints toward
+                # their midpoints so the next command in either direction has
+                # full range available.
+                if np.linalg.norm(primary_vel) < 0.05:
+                    wrist_mid = (self._q_lo[3:6] + self._q_hi[3:6]) / 2.0
+                    center_vel = 0.3 * (wrist_mid - solve_q[3:6])
+                    center_vel = np.clip(center_vel, -max_jv, max_jv)
+                    dq[3:6] = center_vel
+            else:
+                dq, joints_clipped, vel_scale = _solve_prioritized_task_velocity(
+                    current_q=solve_q,
+                    primary_jacobian=primary_jacobian,
+                    primary_vel=primary_vel,
+                    secondary_jacobian=secondary_jacobian,
+                    secondary_vel=secondary_vel,
+                    q_lo=self._q_lo,
+                    q_hi=self._q_hi,
+                    dt=self._dt,
+                    max_joint_vel=max_jv,
+                    damping=lam,
+                    joint_weights=joint_weights,
+                    secondary_weight=secondary_weight,
+                )
         except np.linalg.LinAlgError:
             self.get_logger().warn('DLS solve failed.')
             return
-
-        if not self._linear_mode:
-            dq = _remove_task_space_velocity(
-                dq=dq,
-                task_jacobian=Jlin,
-                joint_weights=joint_weights,
-                damping=min(lam, 1e-4),
-            )
-            dq = _clamp_joint_velocity_to_limits(
-                solve_q[:active_dofs],
-                dq,
-                self._q_lo[:active_dofs],
-                self._q_hi[:active_dofs],
-                self._dt,
-            )
-            dq = _remove_task_space_velocity(
-                dq=dq,
-                task_jacobian=Jlin,
-                joint_weights=joint_weights,
-                damping=min(lam, 1e-4),
-            )
-            dq = _clamp_joint_velocity_to_limits(
-                solve_q[:active_dofs],
-                dq,
-                self._q_lo[:active_dofs],
-                self._q_hi[:active_dofs],
-                self._dt,
-            )
 
         if (
             self._linear_mode

--- a/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
+++ b/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
@@ -1926,31 +1926,54 @@ class CartesianArmController(Node):
             )
             if not self._linear_mode and active_dofs >= 6:
                 # Rotation mode: solve ONLY with the 3×3 wrist sub-Jacobian so
-                # that q0/q1/q2 (proximal joints) are structurally excluded from
-                # the solve and can never move.
+                # that q0/q1/q2 are structurally excluded and never move.
                 wrist_jacobian = J[3:6, 3:6]
                 wrist_weights = self._joint_weights[3:6]
-                dq_wrist, joints_clipped, vel_scale = _solve_task_velocity_with_limit_redistribution(
-                    current_q=solve_q[3:6],
-                    task_jacobian=wrist_jacobian,
-                    cart_vel=primary_vel,
-                    q_lo=self._q_lo[3:6],
-                    q_hi=self._q_hi[3:6],
-                    dt=self._dt,
-                    max_joint_vel=max_jv,
-                    damping=lam,
-                    joint_weights=wrist_weights,
-                )
+                wrist_mid = (self._q_lo[3:6] + self._q_hi[3:6]) / 2.0
+                cmd_norm = float(np.linalg.norm(primary_vel))
                 dq = np.zeros(active_dofs)
-                dq[3:6] = dq_wrist
-                # When joystick is idle, gently recenter wrist joints toward
-                # their midpoints so the next command in either direction has
-                # full range available.
-                if np.linalg.norm(primary_vel) < 0.05:
-                    wrist_mid = (self._q_lo[3:6] + self._q_hi[3:6]) / 2.0
+                if cmd_norm < 0.05:
+                    # Joystick idle: recenter wrist joints toward their midpoints
+                    # so the next command in either direction has full range.
                     center_vel = 0.3 * (wrist_mid - solve_q[3:6])
                     center_vel = np.clip(center_vel, -max_jv, max_jv)
                     dq[3:6] = center_vel
+                    joints_clipped = []
+                    vel_scale = 1.0
+                else:
+                    # Active rotation command: solve wrist-only.
+                    # Blend in a gentle centering bias on q3/q5 so they don't
+                    # accumulate at limits across repeated pan commands.
+                    # The centering bias scales down to zero near the midpoint.
+                    center_gain = 0.15
+                    center_bias = center_gain * (wrist_mid - solve_q[3:6])
+                    # Only apply centering on q3 and q5 (the ±π wrap joints).
+                    # q4 (wrist_pitch) is asymmetric and naturally stays bounded.
+                    center_vel_full = np.zeros(3)
+                    center_vel_full[0] = center_bias[0]  # q3
+                    center_vel_full[2] = center_bias[2]  # q5
+                    # Modified cart_vel = commanded + centering projected through J.
+                    # Instead of modifying cart_vel (which would corrupt the angular
+                    # command), inject centering directly into dq after the solve.
+                    dq_wrist, joints_clipped, vel_scale = _solve_task_velocity_with_limit_redistribution(
+                        current_q=solve_q[3:6],
+                        task_jacobian=wrist_jacobian,
+                        cart_vel=primary_vel,
+                        q_lo=self._q_lo[3:6],
+                        q_hi=self._q_hi[3:6],
+                        dt=self._dt,
+                        max_joint_vel=max_jv,
+                        damping=lam,
+                        joint_weights=wrist_weights,
+                    )
+                    # Add centering bias in the nullspace of the 3×3 wrist Jacobian.
+                    # The 3×3 wrist Jacobian is square (no nullspace), so we use
+                    # a weighted addition that diminishes with command magnitude.
+                    # At full stick the bias is negligible; near zero it ramps up.
+                    bias_scale = float(np.clip(1.0 - cmd_norm / 0.8, 0.0, 1.0))
+                    dq_wrist = dq_wrist + bias_scale * center_vel_full
+                    dq_wrist = np.clip(dq_wrist, -max_jv, max_jv)
+                    dq[3:6] = dq_wrist
             else:
                 dq, joints_clipped, vel_scale = _solve_prioritized_task_velocity(
                     current_q=solve_q,

--- a/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
+++ b/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
@@ -1793,7 +1793,7 @@ class CartesianArmController(Node):
                 )
                 angular_vel = _clip_vector(
                     hold_gain
-                    * _forward_axis_error_vector(
+                    * _rotation_error_vector(
                         current_rotation=current_rotation,
                         desired_rotation=self._forward_rotation,
                     ),

--- a/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
+++ b/reseq_arm_mk2/reseq_arm_mk2/cartesian_arm_controller.py
@@ -222,6 +222,58 @@ def _forward_axis_error_vector(
     return np.cross(current_forward, desired_forward)
 
 
+def _forward_axis_alignment_error(
+    current_rotation: np.ndarray,
+    desired_rotation: np.ndarray,
+) -> float:
+    """Return the angular error between the current and desired forward axes."""
+    current_forward = current_rotation[:, 0]
+    desired_forward = desired_rotation[:, 0]
+    current_norm = np.linalg.norm(current_forward)
+    desired_norm = np.linalg.norm(desired_forward)
+    if current_norm < 1e-9 or desired_norm < 1e-9:
+        return 0.0
+    current_forward = current_forward / current_norm
+    desired_forward = desired_forward / desired_norm
+    cos_error = float(np.clip(np.dot(current_forward, desired_forward), -1.0, 1.0))
+    return float(np.arccos(cos_error))
+
+
+def _forward_progress_is_acceptable(
+    current_error: float,
+    next_error: float,
+    tolerance: float = 0.02,
+    epsilon: float = 1e-4,
+) -> bool:
+    """Return whether a predicted command preserves or recovers forward-look."""
+    if next_error <= tolerance:
+        return True
+    if next_error > current_error + epsilon:
+        return False
+    if current_error > tolerance and next_error >= current_error - epsilon:
+        return False
+    return True
+
+
+def _task_velocity_direction_is_acceptable(
+    desired_vel: np.ndarray,
+    achieved_vel: np.ndarray,
+    deadzone: float,
+) -> bool:
+    """Return whether the dominant commanded task axis still moves as requested."""
+    desired = np.asarray(desired_vel, dtype=float).reshape(-1)
+    achieved = np.asarray(achieved_vel, dtype=float).reshape(-1)
+    if desired.size == 0 or achieved.size != desired.size:
+        return True
+
+    axis = int(np.argmax(np.abs(desired)))
+    desired_axis = float(desired[axis])
+    if abs(desired_axis) <= deadzone:
+        return True
+    achieved_axis = float(achieved[axis])
+    return achieved_axis * desired_axis > 1e-6
+
+
 def _dominant_rotation_input(cmd_vel: np.ndarray, deadzone: float) -> np.ndarray:
     """Keep full-stick rotation commands on one tool axis."""
     filtered = np.array(cmd_vel, dtype=float, copy=True)
@@ -543,7 +595,7 @@ def _linear_startup_escape_velocity(
         return escape
 
     strength = float(np.clip((margin - elbow_distance) / margin, 0.0, 1.0))
-    escape[0] = 0.20 * max_joint_vel * strength
+    escape[0] = -0.20 * max_joint_vel * strength
     escape[2] = 0.95 * max_joint_vel * strength
 
     wrist_room = float(current_q[4] - q_lo[4])
@@ -551,6 +603,99 @@ def _linear_startup_escape_velocity(
         wrist_scale = float(np.clip(wrist_room / wrist_margin, 0.0, 1.0))
         escape[4] = -0.15 * max_joint_vel * strength * wrist_scale
     return escape
+
+
+def _is_lower_elbow_positive_z_recovery_active(
+    current_q: np.ndarray,
+    q_lo: np.ndarray,
+    cart_vel_cmd: np.ndarray,
+    deadzone: float,
+    margin: float = 0.03,
+) -> bool:
+    return (
+        len(current_q) > 4
+        and _is_dominant_positive_z_command(cart_vel_cmd, deadzone)
+        and float(current_q[2]) <= float(q_lo[2]) + margin
+    )
+
+
+def _lower_elbow_positive_z_escape_velocity(
+    current_q: np.ndarray,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+    max_joint_vel: float,
+    shoulder_reserve: float = 0.18,
+    wrist_reserve: float = 0.18,
+) -> np.ndarray:
+    """Lift from the folded lower-elbow stop without depending on elbow motion."""
+    escape = np.zeros_like(current_q)
+    if len(current_q) < 5:
+        return escape
+
+    if current_q[0] > q_lo[0] + shoulder_reserve:
+        escape[0] = -0.35 * max_joint_vel
+    if current_q[2] < q_hi[2] - 1e-4:
+        escape[2] = max_joint_vel
+    if current_q[4] > q_lo[4] + wrist_reserve:
+        escape[4] = -0.35 * max_joint_vel
+    return escape
+
+
+def _lower_elbow_corner_unstick_velocity(
+    current_q: np.ndarray,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+    max_joint_vel: float,
+    shoulder_reserve: float = 0.18,
+    wrist_reserve: float = 0.18,
+) -> np.ndarray:
+    """Open a tucked lower-elbow corner before trying to optimize vertical FK."""
+    escape = np.zeros_like(current_q)
+    if len(current_q) < 5:
+        return escape
+
+    if current_q[0] <= q_lo[0] + shoulder_reserve:
+        escape[0] = 0.45 * max_joint_vel
+    if current_q[2] < q_hi[2] - 1e-4:
+        escape[2] = 0.75 * max_joint_vel
+    if current_q[4] <= q_lo[4] + wrist_reserve:
+        escape[4] = 0.45 * max_joint_vel
+    return escape
+
+
+def _lower_elbow_command_spends_stop_reserve(
+    current_q: np.ndarray,
+    dq: np.ndarray,
+    q_lo: np.ndarray,
+    shoulder_reserve: float = 0.18,
+    wrist_reserve: float = 0.18,
+) -> bool:
+    if len(current_q) < 5 or len(dq) < 5:
+        return False
+
+    shoulder_spends = (
+        current_q[0] <= q_lo[0] + shoulder_reserve
+        and dq[0] < -1e-6
+    )
+    wrist_spends = (
+        current_q[4] <= q_lo[4] + wrist_reserve
+        and dq[4] < -1e-6
+    )
+    return bool(shoulder_spends or wrist_spends)
+
+
+def _is_lower_elbow_hard_corner(
+    current_q: np.ndarray,
+    q_lo: np.ndarray,
+    shoulder_margin: float = 0.04,
+    wrist_margin: float = 0.08,
+) -> bool:
+    if len(current_q) < 5:
+        return False
+    return bool(
+        current_q[0] <= q_lo[0] + shoulder_margin
+        or current_q[4] <= q_lo[4] + wrist_margin
+    )
 
 
 def _dominant_z_lift_velocity(
@@ -581,6 +726,70 @@ def _dominant_z_lift_velocity(
     return lifted
 
 
+def _solve_directional_z_velocity(
+    current_q: np.ndarray,
+    z_jacobian: np.ndarray,
+    desired_z_vel: float,
+    q_lo: np.ndarray,
+    q_hi: np.ndarray,
+    dt: float,
+    max_joint_vel: float,
+    damping: float,
+    joint_weights: np.ndarray,
+) -> tuple[np.ndarray, list[str], float]:
+    """Solve Z using only joints whose instantaneous motion helps the requested direction."""
+    z_row = np.asarray(z_jacobian, dtype=float).reshape(-1)
+    helpful = np.abs(z_row) > 1e-9
+    if not np.any(helpful):
+        return np.zeros_like(current_q), ['Z↕no_helpful_joint'], 0.0
+
+    helpful_indices = np.flatnonzero(helpful)
+    dq_helpful, clipped, scale = _solve_task_velocity_with_limit_redistribution(
+        current_q=current_q[helpful_indices],
+        task_jacobian=z_jacobian[:, helpful_indices],
+        cart_vel=np.array([desired_z_vel]),
+        q_lo=q_lo[helpful_indices],
+        q_hi=q_hi[helpful_indices],
+        dt=dt,
+        max_joint_vel=max_joint_vel,
+        damping=damping,
+        joint_weights=joint_weights[helpful_indices],
+    )
+    dq = np.zeros_like(current_q)
+    dq[helpful_indices] = dq_helpful
+    mapped_clipped = []
+    for label in clipped:
+        if label.startswith('J') and len(label) >= 3:
+            try:
+                local_idx = int(label[1:-1])
+            except ValueError:
+                mapped_clipped.append(label)
+            else:
+                mapped_clipped.append(f'J{helpful_indices[local_idx]}{label[-1]}')
+        else:
+            mapped_clipped.append(label)
+    return dq, mapped_clipped, scale
+
+
+def _minimum_positive_z_progress(desired_z_vel: float) -> float:
+    return 0.25 * abs(float(desired_z_vel))
+
+
+def _linear_command_target_dt(
+    command_mode: str,
+    horizon: float,
+    control_dt: float,
+    cart_vel_cmd: np.ndarray,
+    deadzone: float,
+) -> float:
+    if (
+        command_mode == 'trajectory'
+        and _is_dominant_positive_z_command(cart_vel_cmd, deadzone)
+    ):
+        return control_dt
+    return horizon
+
+
 def _linear_lateral_forward_velocity(
     cart_vel: np.ndarray,
     cart_vel_cmd: np.ndarray,
@@ -588,32 +797,14 @@ def _linear_lateral_forward_velocity(
     deadzone: float,
     front_branch_gain: float,
 ) -> np.ndarray:
-    """Bias pure left/right linear commands onto the forward arm branch."""
-    biased = np.array(cart_vel, dtype=float, copy=True)
-    lateral_cmd = abs(float(cart_vel_cmd[1]))
-    explicit_x_cmd = abs(float(cart_vel_cmd[0])) > deadzone
-    if (
-        explicit_x_cmd
-        or lateral_cmd <= deadzone
-        or _is_dominant_z_command(cart_vel_cmd, deadzone)
-    ):
-        return biased
-
-    forward_bias = max(
-        abs(front_branch_gain) * max_cartesian_vel,
-        0.25 * lateral_cmd,
-    )
-    forward_bias = min(forward_bias, 0.45 * max_cartesian_vel)
-    biased[0] = max(float(biased[0]), forward_bias)
-    return biased
+    """Keep manual lateral commands literal; no artificial X branch bias."""
+    del cart_vel_cmd, max_cartesian_vel, deadzone, front_branch_gain
+    return np.array(cart_vel, dtype=float, copy=True)
 
 
 def _is_lateral_forward_bias_active(cart_vel_cmd: np.ndarray, deadzone: float) -> bool:
-    return (
-        abs(float(cart_vel_cmd[1])) > deadzone
-        and abs(float(cart_vel_cmd[0])) <= deadzone
-        and not _is_dominant_z_command(cart_vel_cmd, deadzone)
-    )
+    del cart_vel_cmd, deadzone
+    return False
 
 
 def _is_dominant_positive_z_command(cart_vel_cmd: np.ndarray, deadzone: float) -> bool:
@@ -1032,6 +1223,302 @@ class CartesianArmController(Node):
             return None
         return self._rotation_kdl_to_matrix(frame.M)
 
+    def _next_q_from_dq(
+        self,
+        current_q: np.ndarray,
+        dq: np.ndarray,
+        dt: float,
+        active_dofs: int,
+    ) -> np.ndarray:
+        next_q = np.array(current_q, dtype=float, copy=True)
+        next_q[:active_dofs] = np.clip(
+            current_q[:active_dofs] + dq[:active_dofs] * dt,
+            self._q_lo[:active_dofs],
+            self._q_hi[:active_dofs],
+        )
+        return next_q
+
+    def _forward_error_at_q(self, q: np.ndarray) -> float | None:
+        rotation = self._get_ee_rotation(q)
+        if rotation is None:
+            return None
+        return _forward_axis_alignment_error(rotation, self._forward_rotation)
+
+    def _enforce_linear_forward_progress(
+        self,
+        current_q: np.ndarray,
+        dq: np.ndarray,
+        angular_jacobian: np.ndarray,
+        angular_vel: np.ndarray,
+        linear_task_jacobian: np.ndarray,
+        linear_task_vel: np.ndarray,
+        joint_weights: np.ndarray,
+        max_joint_vel: float,
+        damping: float,
+        deadzone: float,
+        active_dofs: int,
+    ) -> tuple[np.ndarray, list[str], float, float | None, float | None]:
+        current_error = self._forward_error_at_q(current_q)
+        if current_error is None:
+            return dq, [], 1.0, None, None
+
+        next_error = self._forward_error_at_q(
+            self._next_q_from_dq(current_q, dq, self._dt, active_dofs)
+        )
+        achieved_task_vel = linear_task_jacobian @ dq[:active_dofs]
+        if (
+            next_error is None
+            or (
+                _forward_progress_is_acceptable(current_error, next_error)
+                and _task_velocity_direction_is_acceptable(
+                    linear_task_vel, achieved_task_vel, deadzone
+                )
+            )
+        ):
+            return dq, [], 1.0, current_error, next_error
+
+        best_dq = np.zeros_like(dq)
+        best_error = current_error
+        best_scale = 0.0
+        best_clipped: list[str] = []
+        best_preserves_direction = False
+        for translation_scale in (1.0, 0.75, 0.5, 0.25, 0.1, 0.0):
+            secondary_jacobian = None
+            secondary_vel = None
+            if translation_scale > 0.0:
+                secondary_jacobian, secondary_vel = _append_secondary_task(
+                    secondary_jacobian=secondary_jacobian,
+                    secondary_vel=secondary_vel,
+                    task_jacobian=linear_task_jacobian,
+                    task_vel=translation_scale * linear_task_vel,
+                    weight=1.0,
+                )
+
+            try:
+                candidate_dq, candidate_clipped, _ = _solve_prioritized_task_velocity(
+                    current_q=current_q,
+                    primary_jacobian=angular_jacobian,
+                    primary_vel=angular_vel,
+                    secondary_jacobian=secondary_jacobian,
+                    secondary_vel=secondary_vel,
+                    q_lo=self._q_lo[:active_dofs],
+                    q_hi=self._q_hi[:active_dofs],
+                    dt=self._dt,
+                    max_joint_vel=max_joint_vel,
+                    damping=damping,
+                    joint_weights=joint_weights,
+                    secondary_weight=1.0,
+                )
+            except np.linalg.LinAlgError:
+                continue
+
+            candidate_error = self._forward_error_at_q(
+                self._next_q_from_dq(current_q, candidate_dq, self._dt, active_dofs)
+            )
+            if candidate_error is None:
+                continue
+            candidate_task_vel = linear_task_jacobian @ candidate_dq[:active_dofs]
+            direction_ok = _task_velocity_direction_is_acceptable(
+                linear_task_vel, candidate_task_vel, deadzone
+            )
+            if (
+                direction_ok
+                and (
+                    not best_preserves_direction
+                    or candidate_error < best_error
+                )
+            ):
+                best_dq = candidate_dq
+                best_error = candidate_error
+                best_scale = translation_scale
+                best_clipped = candidate_clipped
+                best_preserves_direction = True
+            elif not best_preserves_direction and candidate_error < best_error:
+                best_dq = candidate_dq
+                best_error = candidate_error
+                best_scale = translation_scale
+                best_clipped = candidate_clipped
+            if (
+                direction_ok
+                and _forward_progress_is_acceptable(current_error, candidate_error)
+            ):
+                return (
+                    candidate_dq,
+                    [*candidate_clipped, f'forward_guard:{translation_scale:.2f}'],
+                    translation_scale,
+                    current_error,
+                    candidate_error,
+                )
+
+        if best_preserves_direction and best_error < current_error:
+            return (
+                best_dq,
+                [*best_clipped, f'forward_guard:{best_scale:.2f}'],
+                best_scale,
+                current_error,
+                best_error,
+            )
+        return np.zeros_like(dq), ['forward_hold'], 0.0, current_error, current_error
+
+    def _enforce_positive_z_fk_progress(
+        self,
+        current_q: np.ndarray,
+        dq: np.ndarray,
+        cart_vel_cmd: np.ndarray,
+        deadzone: float,
+        max_joint_vel: float,
+        active_dofs: int,
+    ) -> tuple[np.ndarray, list[str]]:
+        if not _is_dominant_positive_z_command(cart_vel_cmd, deadzone):
+            return dq, []
+
+        current_z = float(self._get_ee_pos(current_q)[2])
+        pin_lower_elbow = _is_lower_elbow_positive_z_recovery_active(
+            current_q=current_q[:active_dofs],
+            q_lo=self._q_lo[:active_dofs],
+            cart_vel_cmd=cart_vel_cmd,
+            deadzone=deadzone,
+        )
+
+        def next_q_for(candidate_dq: np.ndarray) -> np.ndarray:
+            candidate_next_q = self._next_q_from_dq(
+                current_q,
+                candidate_dq,
+                self._dt,
+                active_dofs,
+            )
+            if pin_lower_elbow:
+                candidate_next_q[2] = current_q[2]
+            return candidate_next_q
+
+        def z_delta_for(candidate_dq: np.ndarray) -> float:
+            return float(self._get_ee_pos(next_q_for(candidate_dq))[2]) - current_z
+
+        current_delta = z_delta_for(dq)
+        lower_elbow_hard_corner = pin_lower_elbow and _is_lower_elbow_hard_corner(
+            current_q=current_q[:active_dofs],
+            q_lo=self._q_lo[:active_dofs],
+        )
+        spends_stop_reserve = pin_lower_elbow and _lower_elbow_command_spends_stop_reserve(
+            current_q=current_q[:active_dofs],
+            dq=dq[:active_dofs],
+            q_lo=self._q_lo[:active_dofs],
+        )
+        if lower_elbow_hard_corner or spends_stop_reserve:
+            corner_unstick = _lower_elbow_corner_unstick_velocity(
+                current_q=current_q[:active_dofs],
+                q_lo=self._q_lo[:active_dofs],
+                q_hi=self._q_hi[:active_dofs],
+                max_joint_vel=max_joint_vel,
+            )
+            corner_unstick = _clamp_joint_velocity_to_limits(
+                current_q[:active_dofs],
+                corner_unstick,
+                self._q_lo[:active_dofs],
+                self._q_hi[:active_dofs],
+                self._dt,
+            )
+            if np.linalg.norm(corner_unstick) > 1e-9:
+                return corner_unstick, ['Z↑corner_unstick']
+        if current_delta > 2e-4:
+            return dq, []
+
+        candidates: list[tuple[str, np.ndarray]] = []
+        elbow_unstick = np.zeros(active_dofs)
+        if active_dofs > 2 and current_q[2] < self._q_hi[2] - 1e-4:
+            elbow_unstick[2] = max_joint_vel
+
+        if pin_lower_elbow:
+            lower_escape = _lower_elbow_positive_z_escape_velocity(
+                current_q=current_q[:active_dofs],
+                q_lo=self._q_lo[:active_dofs],
+                q_hi=self._q_hi[:active_dofs],
+                max_joint_vel=max_joint_vel,
+            )
+            candidates.append(('Z↑lower_escape', lower_escape))
+
+            corner_unstick = _lower_elbow_corner_unstick_velocity(
+                current_q=current_q[:active_dofs],
+                q_lo=self._q_lo[:active_dofs],
+                q_hi=self._q_hi[:active_dofs],
+                max_joint_vel=max_joint_vel,
+            )
+            if np.linalg.norm(corner_unstick) > 1e-9:
+                candidates.append(('Z↑corner_unstick', corner_unstick))
+
+            q4_lift = np.zeros(active_dofs)
+            if active_dofs > 4 and current_q[4] > self._q_lo[4] + 0.18:
+                q4_lift[4] = -max_joint_vel
+                candidates.append(('Z↑wrist_lift', q4_lift))
+
+            q0_lift = np.zeros(active_dofs)
+            if current_q[0] > self._q_lo[0] + 0.18:
+                q0_lift[0] = -max_joint_vel
+                candidates.append(('Z↑shoulder_lift', q0_lift))
+
+            combined_lift = q0_lift + q4_lift
+            if np.linalg.norm(combined_lift) > 1e-9:
+                candidates.append(('Z↑shoulder_wrist_lift', combined_lift))
+            if np.linalg.norm(elbow_unstick) > 1e-9:
+                candidates.append(('Z↑elbow_unstick', elbow_unstick))
+
+        startup_escape = _linear_startup_escape_velocity(
+            current_q=current_q[:active_dofs],
+            q_lo=self._q_lo[:active_dofs],
+            max_joint_vel=max_joint_vel,
+            cart_vel_cmd=cart_vel_cmd,
+            deadzone=deadzone,
+        )
+        if np.linalg.norm(startup_escape) > 1e-9:
+            candidates.append(('Z↑startup_escape', startup_escape))
+
+        best_dq = dq
+        best_label = 'Z↑blocked'
+        best_delta = current_delta
+        current_forward_error = self._forward_error_at_q(current_q)
+        best_forward_ok = False
+
+        for label, candidate in candidates:
+            candidate = _clamp_joint_velocity_to_limits(
+                current_q[:active_dofs],
+                candidate[:active_dofs],
+                self._q_lo[:active_dofs],
+                self._q_hi[:active_dofs],
+                self._dt,
+            )
+            candidate_delta = z_delta_for(candidate)
+            if candidate_delta <= best_delta + 1e-5:
+                continue
+
+            candidate_forward_error = self._forward_error_at_q(next_q_for(candidate))
+            forward_ok = (
+                current_forward_error is None
+                or candidate_forward_error is None
+                or _forward_progress_is_acceptable(
+                    current_forward_error,
+                    candidate_forward_error,
+                    tolerance=0.05,
+                )
+            )
+            if forward_ok or not best_forward_ok:
+                best_dq = candidate
+                best_label = label
+                best_delta = candidate_delta
+                best_forward_ok = forward_ok
+
+        if best_delta > 2e-4:
+            return best_dq, [best_label]
+        if pin_lower_elbow and np.linalg.norm(elbow_unstick) > 1e-9:
+            elbow_unstick = _clamp_joint_velocity_to_limits(
+                current_q[:active_dofs],
+                elbow_unstick,
+                self._q_lo[:active_dofs],
+                self._q_hi[:active_dofs],
+                self._dt,
+            )
+            return elbow_unstick, ['Z↑elbow_unstick']
+        return np.zeros_like(dq), ['Z↑blocked']
+
     def _fk_numerical(self, q: np.ndarray) -> np.ndarray:
         """
         Simple FK fallback for cases where KDL is not available.
@@ -1234,12 +1721,17 @@ class CartesianArmController(Node):
         active_dofs = J.shape[1]
         Jlin = J[:3, :active_dofs]
         cart_vel_cmd = self._cmd_vel * max_cv
+        command_target_dt = horizon
+        if abs(float(cart_vel_cmd[2])) >= deadzone:
+            self._ee_z_ref = float(self._get_ee_pos(solve_q)[2])
         cart_vel = np.zeros(3)
         angular_vel = np.zeros(3)
         secondary_jacobian = None
         secondary_vel = None
         primary_jacobian = Jlin
         primary_vel = cart_vel
+        forward_error_before = None
+        forward_error_after = None
         mode_label = 'linear'
         startup_unfold_primary = False
 
@@ -1260,6 +1752,13 @@ class CartesianArmController(Node):
                 max_cartesian_vel=max_cv,
                 deadzone=deadzone,
                 front_branch_gain=self._front_branch_gain,
+            )
+            command_target_dt = _linear_command_target_dt(
+                command_mode=self._command_mode,
+                horizon=horizon,
+                control_dt=self._dt,
+                cart_vel_cmd=cart_vel_cmd,
+                deadzone=deadzone,
             )
 
             # Hold the current height unless the user is explicitly commanding Z.
@@ -1282,7 +1781,7 @@ class CartesianArmController(Node):
             primary_jacobian = linear_task_jacobian
             primary_vel = linear_task_vel
             current_rotation = self._get_ee_rotation(solve_q)
-            hold_orientation = not _is_dominant_z_command(cart_vel_cmd, deadzone)
+            hold_orientation = True
             if current_rotation is not None and hold_orientation:
                 hold_gain = (
                     self.get_parameter('orientation_hold_gain').get_parameter_value().double_value
@@ -1468,6 +1967,9 @@ class CartesianArmController(Node):
             z_jacobian = Jlin[2:3, :]
             desired_z_vel = float(cart_vel[2])
             achieved_z_vel = float((z_jacobian @ dq[:active_dofs])[0])
+            min_z_progress = 0.0
+            if _is_dominant_positive_z_command(cart_vel_cmd, deadzone):
+                min_z_progress = _minimum_positive_z_progress(desired_z_vel)
             z_error = achieved_z_vel - desired_z_vel
             if abs(z_error) > 1e-4:
                 z_correction = _solve_weighted_dls_task_velocity(
@@ -1487,12 +1989,18 @@ class CartesianArmController(Node):
 
             if (
                 abs(desired_z_vel) > deadzone
-                and achieved_z_vel * desired_z_vel <= 0.0
+                and (
+                    achieved_z_vel * desired_z_vel <= 0.0
+                    or (
+                        _is_dominant_positive_z_command(cart_vel_cmd, deadzone)
+                        and achieved_z_vel < min_z_progress
+                    )
+                )
             ):
-                z_only_dq, z_only_clipped, z_only_scale = _solve_task_velocity_with_limit_redistribution(
+                z_only_dq, z_only_clipped, z_only_scale = _solve_directional_z_velocity(
                     current_q=solve_q[:active_dofs],
-                    task_jacobian=z_jacobian,
-                    cart_vel=np.array([desired_z_vel]),
+                    z_jacobian=z_jacobian,
+                    desired_z_vel=desired_z_vel,
                     q_lo=self._q_lo[:active_dofs],
                     q_hi=self._q_hi[:active_dofs],
                     dt=self._dt,
@@ -1501,7 +2009,9 @@ class CartesianArmController(Node):
                     joint_weights=joint_weights,
                 )
                 z_only_vel = float((z_jacobian @ z_only_dq[:active_dofs])[0])
-                if z_only_vel * desired_z_vel > 0.0:
+                if (
+                    z_only_vel * desired_z_vel > 0.0
+                ):
                     dq = z_only_dq
                     joints_clipped = [*joints_clipped, *z_only_clipped, 'Z↕guard']
                     vel_scale = min(vel_scale, z_only_scale)
@@ -1596,12 +2106,52 @@ class CartesianArmController(Node):
                     dq = np.zeros_like(dq)
                     joints_clipped = [*joints_clipped, 'Z↑blocked']
 
+        if self._linear_mode:
+            (
+                dq,
+                forward_guard_clipped,
+                forward_guard_scale,
+                forward_error_before,
+                forward_error_after,
+            ) = self._enforce_linear_forward_progress(
+                current_q=solve_q,
+                dq=dq[:active_dofs],
+                angular_jacobian=J[3:6, :active_dofs],
+                angular_vel=angular_vel,
+                linear_task_jacobian=linear_task_jacobian,
+                linear_task_vel=linear_task_vel,
+                joint_weights=joint_weights,
+                max_joint_vel=max_jv,
+                damping=lam,
+                deadzone=deadzone,
+                active_dofs=active_dofs,
+            )
+            if forward_guard_clipped:
+                joints_clipped = [*joints_clipped, *forward_guard_clipped]
+                vel_scale = min(vel_scale, forward_guard_scale)
+
+            (
+                dq,
+                positive_z_fk_clipped,
+            ) = self._enforce_positive_z_fk_progress(
+                current_q=solve_q,
+                dq=dq[:active_dofs],
+                cart_vel_cmd=cart_vel_cmd,
+                deadzone=deadzone,
+                max_joint_vel=max_jv,
+                active_dofs=active_dofs,
+            )
+            if positive_z_fk_clipped:
+                joints_clipped = [*joints_clipped, *positive_z_fk_clipped]
+                if positive_z_fk_clipped == ['Z↑blocked']:
+                    vel_scale = 0.0
+
         # In trajectory mode, generate the next target from the measured pose.
         # This keeps the published joint step consistent with the Jacobian
         # linearization and avoids accumulating backlog when hardware tracking
         # lags behind the previously commanded target.
         if self._command_mode == 'trajectory':
-            self._q_cmd = np.clip(solve_q + dq * horizon, self._q_lo, self._q_hi)
+            self._q_cmd = np.clip(solve_q + dq * command_target_dt, self._q_lo, self._q_hi)
         else:
             # Velocity mode should hold near the actual arm pose, not a
             # long-horizon prediction. Using the trajectory lookahead here
@@ -1619,6 +2169,11 @@ class CartesianArmController(Node):
         if self._diag_ctr % 33 == 0:
             ee = self._get_ee_pos(self._q_cmd if self._q_cmd is not None else self._q)
             achieved_task = Jlin @ dq[:active_dofs]
+            orientation_diag = ''
+            if forward_error_before is not None and forward_error_after is not None:
+                orientation_diag = (
+                    f'orientation_error={forward_error_before:.3f}->{forward_error_after:.3f} '
+                )
             self.get_logger().info(
                 f'mode={mode_label} '
                 f'cart_in={np.round(cart_vel, 3)} '
@@ -1626,6 +2181,7 @@ class CartesianArmController(Node):
                 f'dq={np.round(dq, 3)} '
                 f'linear_out={np.round(achieved_task, 3)} '
                 f'vel_scale={vel_scale:.2f} '
+                f'{orientation_diag}'
                 f'clipped={joints_clipped} '
                 f'vel_subs={self._vel_pub.get_subscription_count()} '
                 f'vel_legacy_subs={self._vel_pub_legacy.get_subscription_count()}\n'

--- a/reseq_arm_mk2/test/test_cartesian_arm_controller_modes.py
+++ b/reseq_arm_mk2/test/test_cartesian_arm_controller_modes.py
@@ -1,0 +1,326 @@
+import numpy as np
+
+from reseq_arm_mk2.cartesian_arm_controller import (
+    _dominant_z_lift_velocity,
+    _forward_axis_error_vector,
+    _is_dominant_positive_z_command,
+    _is_dominant_z_command,
+    _linear_startup_escape_velocity,
+    _remove_task_space_velocity,
+    _rotation_error_vector,
+    _rotation_matrix_from_rpy,
+    _rotation_mode_angular_velocity,
+    _solve_prioritized_task_velocity,
+    _solve_task_velocity_with_limit_redistribution,
+)
+
+
+def test_rotation_mode_maps_scaler_xyz_to_roll_tilt_pan():
+    angular = _rotation_mode_angular_velocity(
+        cmd_vel=np.array([1.0, 0.5, -0.25]),
+        max_angular_vel=0.8,
+    )
+
+    assert np.allclose(angular, np.array([0.8, -0.2, 0.4]))
+
+
+def test_rotation_error_uses_fixed_robot_forward_orientation():
+    current = _rotation_matrix_from_rpy(0.0, 0.0, 0.25)
+    desired = _rotation_matrix_from_rpy(0.0, 0.0, 0.0)
+
+    error = _rotation_error_vector(
+        current_rotation=current,
+        desired_rotation=desired,
+    )
+
+    assert np.allclose(error, np.array([0.0, 0.0, -0.25]), atol=1e-6)
+
+
+def test_rotation_error_is_zero_when_camera_is_forward():
+    forward = _rotation_matrix_from_rpy(0.0, 0.0, 0.0)
+
+    error = _rotation_error_vector(
+        current_rotation=forward,
+        desired_rotation=forward,
+    )
+
+    assert np.allclose(error, np.zeros(3))
+
+
+def test_forward_axis_error_ignores_roll_about_forward_axis():
+    current = _rotation_matrix_from_rpy(0.8, 0.0, 0.0)
+    desired = _rotation_matrix_from_rpy(0.0, 0.0, 0.0)
+
+    error = _forward_axis_error_vector(
+        current_rotation=current,
+        desired_rotation=desired,
+    )
+
+    assert np.allclose(error, np.zeros(3), atol=1e-6)
+
+
+def test_forward_axis_error_corrects_sideways_tool_axis():
+    current = _rotation_matrix_from_rpy(0.0, 0.0, 0.5)
+    desired = _rotation_matrix_from_rpy(0.0, 0.0, 0.0)
+
+    error = _forward_axis_error_vector(
+        current_rotation=current,
+        desired_rotation=desired,
+    )
+
+    assert error[2] < 0.0
+
+
+def test_startup_z_escape_biases_folded_arm_out_of_lower_elbow_limit():
+    escape = _linear_startup_escape_velocity(
+        current_q=np.array([-0.03, 0.0, -0.1, 0.0, 0.0, 0.0]),
+        q_lo=np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14]),
+        max_joint_vel=0.8,
+        cart_vel_cmd=np.array([0.0, 0.0, 0.2]),
+        deadzone=0.02,
+    )
+
+    assert escape[0] < 0.0
+    assert escape[2] > 0.0
+    assert escape[4] < 0.0
+    assert abs(escape[2]) > abs(escape[0])
+
+
+def test_startup_z_escape_stops_pushing_wrist_at_lower_limit():
+    escape = _linear_startup_escape_velocity(
+        current_q=np.array([0.5, 0.0, -0.1, 0.0, -0.46, 0.0]),
+        q_lo=np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14]),
+        max_joint_vel=0.8,
+        cart_vel_cmd=np.array([0.0, 0.0, 0.2]),
+        deadzone=0.02,
+    )
+
+    assert escape[0] < 0.0
+    assert escape[2] > 0.0
+    assert escape[4] == 0.0
+
+
+def test_startup_z_escape_ignores_non_dominant_z_drift():
+    escape = _linear_startup_escape_velocity(
+        current_q=np.array([-0.03, 0.0, -0.1, 0.0, 0.0, 0.0]),
+        q_lo=np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14]),
+        max_joint_vel=0.8,
+        cart_vel_cmd=np.array([0.2, 0.0, 0.05]),
+        deadzone=0.02,
+    )
+
+    assert np.allclose(escape, np.zeros(6))
+
+
+def test_startup_z_escape_is_inactive_after_unfolding():
+    escape = _linear_startup_escape_velocity(
+        current_q=np.array([0.5, 0.0, 0.3, 0.0, 0.0, 0.0]),
+        q_lo=np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14]),
+        max_joint_vel=0.8,
+        cart_vel_cmd=np.array([0.0, 0.0, 0.2]),
+        deadzone=0.02,
+    )
+
+    assert np.allclose(escape, np.zeros(6))
+
+
+def test_dominant_positive_z_command_filters_normal_xy_stick_motion():
+    assert _is_dominant_positive_z_command(np.array([0.0, 0.0, 0.2]), 0.02)
+    assert not _is_dominant_positive_z_command(np.array([0.2, 0.0, 0.05]), 0.02)
+    assert not _is_dominant_positive_z_command(np.array([0.0, 0.0, -0.2]), 0.02)
+
+
+def test_dominant_z_command_accepts_up_and_down_vertical_commands():
+    assert _is_dominant_z_command(np.array([0.0, 0.0, 0.2]), 0.02)
+    assert _is_dominant_z_command(np.array([0.0, 0.0, -0.2]), 0.02)
+    assert not _is_dominant_z_command(np.array([0.2, 0.0, 0.05]), 0.02)
+
+
+def test_dominant_z_lift_boosts_vertical_without_forward_escape():
+    lifted = _dominant_z_lift_velocity(
+        cart_vel=np.array([0.0, 0.0, 0.2]),
+        current_q=np.array([-0.03, 0.0, -0.1, 0.0, 0.0, 0.0]),
+        q_lo=np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14]),
+        max_cartesian_vel=0.4,
+        cart_vel_cmd=np.array([0.0, 0.0, 0.2]),
+        deadzone=0.02,
+    )
+
+    assert lifted[0] == 0.0
+    assert lifted[2] > 0.2
+
+
+def test_dominant_z_lift_ignores_xy_dominant_motion():
+    lifted = _dominant_z_lift_velocity(
+        cart_vel=np.array([0.2, 0.0, 0.05]),
+        current_q=np.array([-0.03, 0.0, -0.1, 0.0, 0.0, 0.0]),
+        q_lo=np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14]),
+        max_cartesian_vel=0.4,
+        cart_vel_cmd=np.array([0.2, 0.0, 0.05]),
+        deadzone=0.02,
+    )
+
+    assert np.allclose(lifted, np.array([0.2, 0.0, 0.05]))
+
+
+def test_linear_primary_translation_is_not_changed_by_secondary_task():
+    dq, clipped_joints, vel_scale = _solve_prioritized_task_velocity(
+        current_q=np.zeros(2),
+        primary_jacobian=np.array([[1.0, 0.0]]),
+        primary_vel=np.array([0.15]),
+        secondary_jacobian=np.eye(2),
+        secondary_vel=np.array([0.0, -0.2]),
+        q_lo=np.array([-1.0, -1.0]),
+        q_hi=np.array([1.0, 1.0]),
+        dt=0.1,
+        max_joint_vel=1.0,
+        damping=1e-6,
+        joint_weights=np.ones(2),
+        secondary_weight=1.0,
+    )
+
+    assert clipped_joints == []
+    assert vel_scale == 1.0
+    assert np.allclose(np.array([[1.0, 0.0]]) @ dq, np.array([0.15]), atol=1e-6)
+    assert dq[1] < 0.0
+
+
+def test_rotation_primary_keeps_linear_velocity_zero():
+    linear_jacobian = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0],
+        ]
+    )
+    angular_jacobian = np.array([[0.0, 0.0, 1.0]])
+    primary_jacobian = np.vstack((linear_jacobian, angular_jacobian))
+
+    dq, clipped_joints, vel_scale = _solve_prioritized_task_velocity(
+        current_q=np.zeros(3),
+        primary_jacobian=primary_jacobian,
+        primary_vel=np.array([0.0, 0.0, 0.0, 0.4]),
+        secondary_jacobian=None,
+        secondary_vel=None,
+        q_lo=np.array([-1.0, -1.0, -1.0]),
+        q_hi=np.array([1.0, 1.0, 1.0]),
+        dt=0.1,
+        max_joint_vel=1.0,
+        damping=1e-6,
+        joint_weights=np.ones(3),
+        secondary_weight=1.0,
+    )
+
+    assert clipped_joints == []
+    assert vel_scale == 1.0
+    assert np.allclose(linear_jacobian @ dq, np.zeros(3), atol=1e-6)
+    assert np.allclose(angular_jacobian @ dq, np.array([0.4]), atol=1e-6)
+
+
+def test_rotation_projection_removes_linear_drift_from_angular_task():
+    linear_jacobian = np.array(
+        [
+            [1.0, 0.2, 0.0],
+            [0.0, 1.0, 0.1],
+            [0.3, 0.0, 1.0],
+        ]
+    )
+    drifting_dq = np.array([0.12, -0.08, 0.2])
+
+    corrected_dq = _remove_task_space_velocity(
+        dq=drifting_dq,
+        task_jacobian=linear_jacobian,
+        joint_weights=np.ones(3),
+        damping=1e-9,
+    )
+
+    assert np.linalg.norm(linear_jacobian @ corrected_dq) < 1e-6
+
+
+def test_secondary_task_uses_leftover_joint_velocity_budget():
+    primary_jacobian = np.array([[1.0, 0.0]])
+
+    dq, clipped_joints, vel_scale = _solve_prioritized_task_velocity(
+        current_q=np.zeros(2),
+        primary_jacobian=primary_jacobian,
+        primary_vel=np.array([1.0]),
+        secondary_jacobian=np.array([[0.0, 1.0]]),
+        secondary_vel=np.array([2.0]),
+        q_lo=np.array([-2.0, -2.0]),
+        q_hi=np.array([2.0, 2.0]),
+        dt=0.1,
+        max_joint_vel=1.0,
+        damping=1e-6,
+        joint_weights=np.ones(2),
+        secondary_weight=1.0,
+    )
+
+    assert clipped_joints == []
+    assert vel_scale == 1.0
+    assert np.allclose(primary_jacobian @ dq, np.array([1.0]), atol=1e-6)
+    assert dq[1] <= 1.0
+    assert dq[1] > 0.0
+
+
+def test_linear_posture_secondary_escapes_when_primary_direction_is_singular():
+    dq, clipped_joints, vel_scale = _solve_prioritized_task_velocity(
+        current_q=np.array([-0.1, 0.0]),
+        primary_jacobian=np.zeros((1, 2)),
+        primary_vel=np.array([0.2]),
+        secondary_jacobian=np.eye(2),
+        secondary_vel=np.array([0.3, 0.0]),
+        q_lo=np.array([-0.1, -1.0]),
+        q_hi=np.array([1.0, 1.0]),
+        dt=0.1,
+        max_joint_vel=1.0,
+        damping=1e-6,
+        joint_weights=np.ones(2),
+        secondary_weight=1.0,
+    )
+
+    assert clipped_joints == []
+    assert vel_scale == 1.0
+    assert dq[0] > 0.0
+
+
+def test_orientation_secondary_reduces_error_without_overriding_translation():
+    primary_jacobian = np.array([[1.0, 0.0]])
+    secondary_jacobian = np.array([[1.0, 1.0]])
+
+    dq, clipped_joints, vel_scale = _solve_prioritized_task_velocity(
+        current_q=np.zeros(2),
+        primary_jacobian=primary_jacobian,
+        primary_vel=np.array([0.1]),
+        secondary_jacobian=secondary_jacobian,
+        secondary_vel=np.array([0.0]),
+        q_lo=np.array([-1.0, -1.0]),
+        q_hi=np.array([1.0, 1.0]),
+        dt=0.1,
+        max_joint_vel=1.0,
+        damping=1e-6,
+        joint_weights=np.ones(2),
+        secondary_weight=1.0,
+    )
+
+    assert clipped_joints == []
+    assert vel_scale == 1.0
+    assert np.allclose(primary_jacobian @ dq, np.array([0.1]), atol=1e-6)
+    assert abs((secondary_jacobian @ dq)[0]) < 0.02
+
+
+def test_joint_limit_recovery_is_not_added_to_primary_task_directly():
+    dq, clipped_joints, vel_scale = _solve_task_velocity_with_limit_redistribution(
+        current_q=np.array([0.0, -0.95]),
+        task_jacobian=np.array([[1.0, 0.0]]),
+        cart_vel=np.array([0.2]),
+        q_lo=np.array([-1.0, -1.0]),
+        q_hi=np.array([1.0, 1.0]),
+        dt=0.1,
+        max_joint_vel=1.0,
+        damping=1e-6,
+        joint_weights=np.ones(2),
+    )
+
+    assert clipped_joints == []
+    assert vel_scale == 1.0
+    assert np.allclose(dq, np.array([0.2, 0.0]), atol=1e-6)

--- a/reseq_arm_mk2/test/test_cartesian_arm_controller_modes.py
+++ b/reseq_arm_mk2/test/test_cartesian_arm_controller_modes.py
@@ -49,6 +49,19 @@ def test_rotation_error_uses_fixed_robot_forward_orientation():
     assert np.allclose(error, np.array([0.0, 0.0, -0.25]), atol=1e-6)
 
 
+def test_rotation_error_corrects_roll_about_forward_axis():
+    current = _rotation_matrix_from_rpy(0.4, 0.0, 0.0)
+    desired = _rotation_matrix_from_rpy(0.0, 0.0, 0.0)
+
+    error = _rotation_error_vector(
+        current_rotation=current,
+        desired_rotation=desired,
+    )
+
+    assert error[0] < 0.0
+    assert np.allclose(error[1:], np.zeros(2), atol=1e-6)
+
+
 def test_rotation_error_is_zero_when_camera_is_forward():
     forward = _rotation_matrix_from_rpy(0.0, 0.0, 0.0)
 

--- a/reseq_arm_mk2/test/test_cartesian_arm_controller_modes.py
+++ b/reseq_arm_mk2/test/test_cartesian_arm_controller_modes.py
@@ -34,7 +34,7 @@ def test_rotation_mode_maps_scaler_xyz_to_roll_tilt_pan():
         max_angular_vel=0.8,
     )
 
-    assert np.allclose(angular, np.array([0.8, -0.2, 0.4]))
+    assert np.allclose(angular, np.array([0.8, 0.2, 0.4]))
 
 
 def test_rotation_mode_yaw_is_around_base_z_not_tool_z():

--- a/reseq_arm_mk2/test/test_cartesian_arm_controller_modes.py
+++ b/reseq_arm_mk2/test/test_cartesian_arm_controller_modes.py
@@ -2,16 +2,29 @@ import numpy as np
 
 from reseq_arm_mk2.cartesian_arm_controller import (
     _dominant_z_lift_velocity,
+    _forward_axis_alignment_error,
     _forward_axis_error_vector,
+    _forward_progress_is_acceptable,
     _is_dominant_positive_z_command,
     _is_dominant_z_command,
+    _is_lateral_forward_bias_active,
+    _is_lower_elbow_positive_z_recovery_active,
+    _is_lower_elbow_hard_corner,
+    _linear_command_target_dt,
+    _linear_lateral_forward_velocity,
     _linear_startup_escape_velocity,
+    _lower_elbow_command_spends_stop_reserve,
+    _lower_elbow_corner_unstick_velocity,
+    _lower_elbow_positive_z_escape_velocity,
+    _minimum_positive_z_progress,
     _remove_task_space_velocity,
     _rotation_error_vector,
     _rotation_matrix_from_rpy,
     _rotation_mode_angular_velocity,
+    _solve_directional_z_velocity,
     _solve_prioritized_task_velocity,
     _solve_task_velocity_with_limit_redistribution,
+    _task_velocity_direction_is_acceptable,
 )
 
 
@@ -71,6 +84,39 @@ def test_forward_axis_error_corrects_sideways_tool_axis():
     assert error[2] < 0.0
 
 
+def test_forward_axis_alignment_error_measures_axis_angle():
+    current = _rotation_matrix_from_rpy(0.0, 0.0, 0.5)
+    desired = _rotation_matrix_from_rpy(0.0, 0.0, 0.0)
+
+    error = _forward_axis_alignment_error(current, desired)
+
+    assert np.isclose(error, 0.5)
+
+
+def test_forward_progress_requires_recovery_when_not_forward():
+    assert _forward_progress_is_acceptable(0.5, 0.49)
+    assert not _forward_progress_is_acceptable(0.5, 0.5)
+    assert not _forward_progress_is_acceptable(0.5, 0.51)
+
+
+def test_forward_progress_allows_small_error_growth_inside_tolerance():
+    assert _forward_progress_is_acceptable(0.003, 0.015)
+    assert not _forward_progress_is_acceptable(0.003, 0.03)
+
+
+def test_task_velocity_direction_rejects_reversed_dominant_axis():
+    assert _task_velocity_direction_is_acceptable(
+        desired_vel=np.array([0.0, -0.4, 0.0]),
+        achieved_vel=np.array([0.1, -0.02, 0.1]),
+        deadzone=0.02,
+    )
+    assert not _task_velocity_direction_is_acceptable(
+        desired_vel=np.array([0.0, -0.4, 0.0]),
+        achieved_vel=np.array([0.1, 0.02, 0.1]),
+        deadzone=0.02,
+    )
+
+
 def test_startup_z_escape_biases_folded_arm_out_of_lower_elbow_limit():
     escape = _linear_startup_escape_velocity(
         current_q=np.array([-0.03, 0.0, -0.1, 0.0, 0.0, 0.0]),
@@ -124,6 +170,93 @@ def test_startup_z_escape_is_inactive_after_unfolding():
     assert np.allclose(escape, np.zeros(6))
 
 
+def test_lower_elbow_positive_z_recovery_detects_folded_lift_trap():
+    assert _is_lower_elbow_positive_z_recovery_active(
+        current_q=np.array([0.3, 0.0, -0.1, 0.0, -0.08, 0.0]),
+        q_lo=np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14]),
+        cart_vel_cmd=np.array([0.0, 0.0, 0.6]),
+        deadzone=0.02,
+    )
+    assert not _is_lower_elbow_positive_z_recovery_active(
+        current_q=np.array([0.3, 0.0, 0.1, 0.0, -0.08, 0.0]),
+        q_lo=np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14]),
+        cart_vel_cmd=np.array([0.0, 0.0, 0.6]),
+        deadzone=0.02,
+    )
+
+
+def test_lower_elbow_positive_z_escape_uses_shoulder_wrist_and_elbow():
+    escape = _lower_elbow_positive_z_escape_velocity(
+        current_q=np.array([0.3, 0.0, -0.1, 0.0, -0.08, 0.0]),
+        q_lo=np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14]),
+        q_hi=np.array([2.8, 3.14, 2.88, 3.14, 1.57, 3.14]),
+        max_joint_vel=1.6,
+    )
+
+    assert escape[0] < 0.0
+    assert escape[2] > 0.0
+    assert escape[4] < 0.0
+
+
+def test_lower_elbow_positive_z_escape_preserves_stop_reserve():
+    escape = _lower_elbow_positive_z_escape_velocity(
+        current_q=np.array([0.04, 0.0, -0.1, 0.0, -0.35, 0.0]),
+        q_lo=np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14]),
+        q_hi=np.array([2.8, 3.14, 2.88, 3.14, 1.57, 3.14]),
+        max_joint_vel=1.6,
+    )
+
+    assert escape[0] == 0.0
+    assert escape[2] > 0.0
+    assert escape[4] == 0.0
+
+
+def test_lower_elbow_corner_unstick_opens_hard_stop_pose():
+    unstick = _lower_elbow_corner_unstick_velocity(
+        current_q=np.array([-0.1, 0.0, -0.1, 0.0, -0.447, 0.0]),
+        q_lo=np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14]),
+        q_hi=np.array([2.8, 3.14, 2.88, 3.14, 1.57, 3.14]),
+        max_joint_vel=1.6,
+    )
+
+    assert unstick[0] > 0.0
+    assert unstick[2] > 0.0
+    assert unstick[4] > 0.0
+
+
+def test_lower_elbow_command_spends_stop_reserve_detects_tighter_tuck():
+    q_lo = np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14])
+
+    assert _lower_elbow_command_spends_stop_reserve(
+        current_q=np.array([0.02, 0.0, -0.1, 0.0, -0.32, 0.0]),
+        dq=np.array([-0.2, 0.0, 1.0, 0.0, 0.0, 0.0]),
+        q_lo=q_lo,
+    )
+    assert _lower_elbow_command_spends_stop_reserve(
+        current_q=np.array([0.2, 0.0, -0.1, 0.0, -0.34, 0.0]),
+        dq=np.array([0.0, 0.0, 1.0, 0.0, -0.2, 0.0]),
+        q_lo=q_lo,
+    )
+    assert not _lower_elbow_command_spends_stop_reserve(
+        current_q=np.array([0.2, 0.0, -0.1, 0.0, -0.1, 0.0]),
+        dq=np.array([-0.2, 0.0, 1.0, 0.0, -0.2, 0.0]),
+        q_lo=q_lo,
+    )
+
+
+def test_lower_elbow_hard_corner_detects_exact_stuck_pose():
+    q_lo = np.array([-0.1, -3.14, -0.1, -3.14, -0.46, -3.14])
+
+    assert _is_lower_elbow_hard_corner(
+        current_q=np.array([-0.1, 0.0, -0.1, 0.0, -0.447, 0.0]),
+        q_lo=q_lo,
+    )
+    assert not _is_lower_elbow_hard_corner(
+        current_q=np.array([0.02, 0.0, -0.1, 0.0, -0.277, 0.0]),
+        q_lo=q_lo,
+    )
+
+
 def test_dominant_positive_z_command_filters_normal_xy_stick_motion():
     assert _is_dominant_positive_z_command(np.array([0.0, 0.0, 0.2]), 0.02)
     assert not _is_dominant_positive_z_command(np.array([0.2, 0.0, 0.05]), 0.02)
@@ -134,6 +267,39 @@ def test_dominant_z_command_accepts_up_and_down_vertical_commands():
     assert _is_dominant_z_command(np.array([0.0, 0.0, 0.2]), 0.02)
     assert _is_dominant_z_command(np.array([0.0, 0.0, -0.2]), 0.02)
     assert not _is_dominant_z_command(np.array([0.2, 0.0, 0.05]), 0.02)
+
+
+def test_positive_z_trajectory_target_uses_control_tick():
+    assert np.isclose(
+        _linear_command_target_dt(
+            command_mode='trajectory',
+            horizon=0.1,
+            control_dt=1.0 / 33.0,
+            cart_vel_cmd=np.array([0.0, 0.0, 0.6]),
+            deadzone=0.02,
+        ),
+        1.0 / 33.0,
+    )
+    assert np.isclose(
+        _linear_command_target_dt(
+            command_mode='trajectory',
+            horizon=0.1,
+            control_dt=1.0 / 33.0,
+            cart_vel_cmd=np.array([0.0, 0.0, -0.4]),
+            deadzone=0.02,
+        ),
+        0.1,
+    )
+    assert np.isclose(
+        _linear_command_target_dt(
+            command_mode='trajectory',
+            horizon=0.1,
+            control_dt=1.0 / 33.0,
+            cart_vel_cmd=np.array([0.3, 0.0, 0.05]),
+            deadzone=0.02,
+        ),
+        0.1,
+    )
 
 
 def test_dominant_z_lift_boosts_vertical_without_forward_escape():
@@ -161,6 +327,45 @@ def test_dominant_z_lift_ignores_xy_dominant_motion():
     )
 
     assert np.allclose(lifted, np.array([0.2, 0.0, 0.05]))
+
+
+def test_lateral_linear_command_does_not_inject_forward_bias():
+    cart_vel = _linear_lateral_forward_velocity(
+        cart_vel=np.array([0.0, -0.4, 0.0]),
+        cart_vel_cmd=np.array([0.0, -0.4, 0.0]),
+        max_cartesian_vel=0.6,
+        deadzone=0.02,
+        front_branch_gain=0.05,
+    )
+
+    assert np.allclose(cart_vel, np.array([0.0, -0.4, 0.0]))
+    assert not _is_lateral_forward_bias_active(np.array([0.0, -0.4, 0.0]), 0.02)
+
+
+def test_directional_z_solver_uses_only_joints_that_lift_up():
+    dq, clipped, scale = _solve_directional_z_velocity(
+        current_q=np.array([-0.1, -0.1, 0.0]),
+        z_jacobian=np.array([[-0.2, 0.35, -0.15]]),
+        desired_z_vel=0.3,
+        q_lo=np.array([-0.1, -0.1, -1.0]),
+        q_hi=np.array([1.0, 1.0, 1.0]),
+        dt=0.1,
+        max_joint_vel=1.6,
+        damping=1e-6,
+        joint_weights=np.ones(3),
+    )
+
+    assert clipped == ['J0↓']
+    assert scale == 1.0
+    assert dq[0] == 0.0
+    assert dq[1] > 0.0
+    assert dq[2] < 0.0
+    assert float((np.array([[-0.2, 0.35, -0.15]]) @ dq)[0]) > 0.25
+
+
+def test_positive_z_progress_threshold_scales_with_command_size():
+    assert _minimum_positive_z_progress(0.027) < 0.027
+    assert np.isclose(_minimum_positive_z_progress(0.6), 0.15)
 
 
 def test_linear_primary_translation_is_not_changed_by_secondary_task():

--- a/reseq_arm_mk2/test/test_cartesian_arm_controller_modes.py
+++ b/reseq_arm_mk2/test/test_cartesian_arm_controller_modes.py
@@ -37,6 +37,25 @@ def test_rotation_mode_maps_scaler_xyz_to_roll_tilt_pan():
     assert np.allclose(angular, np.array([0.8, -0.2, 0.4]))
 
 
+def test_rotation_mode_yaw_is_around_base_z_not_tool_z():
+    # Tool pitched 90° about Y: tool Z now points along -base X.
+    # Before the fix, a left/right command would rotate around base X (wrong).
+    # With the fix it must produce rotation around base Z only.
+    tool_rotation = _rotation_matrix_from_rpy(0.0, np.pi / 2, 0.0)
+
+    # Pure left/right joystick: _rotation_mode_angular_velocity maps cmd_vel[1] -> tool_angular_vel[2]
+    max_av = 0.8
+    tool_angular_vel = np.array([0.0, 0.0, max_av])
+
+    roll_tilt_tool = np.array([tool_angular_vel[0], tool_angular_vel[1], 0.0])
+    yaw_base = np.array([0.0, 0.0, tool_angular_vel[2]])
+    angular_vel = tool_rotation @ roll_tilt_tool + yaw_base
+
+    assert np.isclose(angular_vel[2], max_av)
+    assert np.isclose(angular_vel[0], 0.0, atol=1e-9)
+    assert np.isclose(angular_vel[1], 0.0, atol=1e-9)
+
+
 def test_rotation_error_uses_fixed_robot_forward_orientation():
     current = _rotation_matrix_from_rpy(0.0, 0.0, 0.25)
     desired = _rotation_matrix_from_rpy(0.0, 0.0, 0.0)

--- a/reseq_arm_mk2/urdf/reseq_arm_mk2.xacro
+++ b/reseq_arm_mk2/urdf/reseq_arm_mk2.xacro
@@ -2,6 +2,12 @@
 
 <robot
   name="reseq_arm_mk2" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property
+    name="arm_pitch_effort"
+    value="${60 if '$(arg sim_mode)' == 'true' else 6}" />
+  <xacro:property
+    name="arm_wrist_pitch_effort"
+    value="${30 if '$(arg sim_mode)' == 'true' else 3}" />
   <link
     name="arm_base_link">
     <inertial>
@@ -97,7 +103,7 @@
     <limit
       lower="-0.1"
       upper="2.8"
-      effort="6"
+      effort="${arm_pitch_effort}"
       velocity="2" />
     <dynamics damping="0.5" friction="0.1" />
   </joint>
@@ -215,7 +221,7 @@
     <limit
       lower="-0.1"
       upper="2.88"
-      effort="6"
+      effort="${arm_pitch_effort}"
       velocity="2" />
     <dynamics damping="0.5" friction="0.1" />
   </joint>
@@ -333,7 +339,7 @@
     <limit
       lower="-0.46"
       upper="1.57"
-      effort="3"
+      effort="${arm_wrist_pitch_effort}"
       velocity="1" />
     <dynamics damping="0.5" friction="0.1" />
   </joint>

--- a/reseq_description/config/templates/reseq_controllers.yaml.j2
+++ b/reseq_description/config/templates/reseq_controllers.yaml.j2
@@ -28,9 +28,11 @@ controller_manager:
 {% endif %}
 
 {% if arm_controller %}
+{% if not use_sim_time %}
     mk2_arm_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
+{% endif %}
     joint_group_velocity_controller:
       type: velocity_controllers/JointGroupVelocityController
 {% endif %}
@@ -61,6 +63,7 @@ diff_controller{{ i + 1 }}:
 {% endif %}
 
 {% if arm_controller %}
+{% if not use_sim_time %}
 mk2_arm_controller:
   ros__parameters:
     joints:
@@ -82,6 +85,7 @@ mk2_arm_controller:
       goals: 0.1
       goal_state: 0.1
 
+{% endif %}
 joint_group_velocity_controller:
   ros__parameters:
     joints:

--- a/reseq_description/description/control/ros2_control.xacro
+++ b/reseq_description/description/control/ros2_control.xacro
@@ -22,6 +22,8 @@
         <gazebo>
             <plugin name="gz_ros2_control::GazeboSimROS2ControlPlugin" filename="libgz_ros2_control-system.so">
                 <parameters>$(find reseq_description)/config/temp/reseq_controllers.yaml</parameters>
+                <hold_joints>true</hold_joints>
+                <position_proportional_gain>0.1</position_proportional_gain>
             </plugin>
         </gazebo>
     </xacro:if>

--- a/reseq_description/description/mk2/arm/control_joints.xacro
+++ b/reseq_description/description/mk2/arm/control_joints.xacro
@@ -2,50 +2,74 @@
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
     <joint name="mod1__base_pitch_arm_joint">
-        <command_interface name="position" />
-        <state_interface name="position" />
+        <xacro:unless value="$(arg sim_mode)">
+            <command_interface name="position" />
+        </xacro:unless>
+        <state_interface name="position">
+            <param name="initial_value">0.0</param>
+        </state_interface>
         <state_interface name="velocity" />
-        <xacro:if value="$(arg sim_mode)" >
+        <xacro:if value="$(arg sim_mode)">
             <command_interface name="velocity" />
         </xacro:if>
     </joint>
     <joint name="mod1__base_roll_arm_joint">
-        <command_interface name="position" />
-        <state_interface name="position" />
+        <xacro:unless value="$(arg sim_mode)">
+            <command_interface name="position" />
+        </xacro:unless>
+        <state_interface name="position">
+            <param name="initial_value">0.0</param>
+        </state_interface>
         <state_interface name="velocity" />
-        <xacro:if value="$(arg sim_mode)" >
+        <xacro:if value="$(arg sim_mode)">
             <command_interface name="velocity" />
         </xacro:if>
     </joint>
     <joint name="mod1__elbow_pitch_arm_joint">
-        <command_interface name="position" />
-        <state_interface name="position" />
+        <xacro:unless value="$(arg sim_mode)">
+            <command_interface name="position" />
+        </xacro:unless>
+        <state_interface name="position">
+            <param name="initial_value">0.0</param>
+        </state_interface>
         <state_interface name="velocity" />
-         <xacro:if value="$(arg sim_mode)" >
+        <xacro:if value="$(arg sim_mode)">
             <command_interface name="velocity" />
         </xacro:if>
     </joint>
     <joint name="mod1__forearm_roll_arm_joint">
-        <command_interface name="position" />
-        <state_interface name="position" />
+        <xacro:unless value="$(arg sim_mode)">
+            <command_interface name="position" />
+        </xacro:unless>
+        <state_interface name="position">
+            <param name="initial_value">0.0</param>
+        </state_interface>
         <state_interface name="velocity" />
-         <xacro:if value="$(arg sim_mode)" >
+        <xacro:if value="$(arg sim_mode)">
             <command_interface name="velocity" />
         </xacro:if>
     </joint>
     <joint name="mod1__wrist_pitch_arm_joint">
-        <command_interface name="position" />
-        <state_interface name="position" />
+        <xacro:unless value="$(arg sim_mode)">
+            <command_interface name="position" />
+        </xacro:unless>
+        <state_interface name="position">
+            <param name="initial_value">0.0</param>
+        </state_interface>
         <state_interface name="velocity" />
-        <xacro:if value="$(arg sim_mode)" >
+        <xacro:if value="$(arg sim_mode)">
             <command_interface name="velocity" />
         </xacro:if>
     </joint>
     <joint name="mod1__wrist_roll_arm_joint">
-        <command_interface name="position" />
-        <state_interface name="position" />
+        <xacro:unless value="$(arg sim_mode)">
+            <command_interface name="position" />
+        </xacro:unless>
+        <state_interface name="position">
+            <param name="initial_value">0.0</param>
+        </state_interface>
         <state_interface name="velocity" />
-        <xacro:if value="$(arg sim_mode)" >
+        <xacro:if value="$(arg sim_mode)">
             <command_interface name="velocity" />
         </xacro:if>
     </joint>

--- a/reseq_ros2/launch/digital_twin_launch.py
+++ b/reseq_ros2/launch/digital_twin_launch.py
@@ -314,17 +314,17 @@ def generate_launch_description():
             DeclareLaunchArgument('sim_mode', default_value='false'),
             DeclareLaunchArgument(
                 'arm_max_cartesian_vel',
-                default_value='0.4',
+                default_value='0.8',
                 description='Cartesian velocity scale for the arm controller',
             ),
             DeclareLaunchArgument(
                 'arm_max_angular_vel',
-                default_value='0.8',
+                default_value='2.4',
                 description='Angular velocity scale for arm rotation mode',
             ),
             DeclareLaunchArgument(
                 'arm_max_joint_vel',
-                default_value='0.8',
+                default_value='1.6',
                 description='Joint velocity clamp for the arm controller',
             ),
             DeclareLaunchArgument(

--- a/reseq_ros2/launch/digital_twin_launch.py
+++ b/reseq_ros2/launch/digital_twin_launch.py
@@ -154,7 +154,8 @@ def launch_setup(context, *args, **kwargs):
         )
         launch_config.append(control_node)
 
-    body_spawners = [_spawner('joint_state_broadcaster', external_log_level)]
+    joint_state_spawner = _spawner('joint_state_broadcaster', external_log_level)
+    body_spawners = []
 
     num_modules = config.get('num_modules', 0)
     for i in range(num_modules):
@@ -167,7 +168,6 @@ def launch_setup(context, *args, **kwargs):
     arm_velocity_spawner = None
     if arm:
         arm_velocity_spawner = _spawner('joint_group_velocity_controller', external_log_level)
-        body_spawners.append(arm_velocity_spawner)
 
     for i in range(num_modules):
         body_spawners.append(_spawner(f'imu{i + 1}_broadcaster', external_log_level))
@@ -191,7 +191,24 @@ def launch_setup(context, *args, **kwargs):
     else:
         launch_config.append(controller_manager_ready)
 
-    _append_spawner_chain(launch_config, controller_manager_ready, body_spawners)
+    launch_config.append(
+        RegisterEventHandler(
+            OnProcessExit(
+                target_action=controller_manager_ready,
+                on_exit=[joint_state_spawner],
+            )
+        )
+    )
+    _append_spawner_chain(launch_config, joint_state_spawner, body_spawners)
+    if arm_velocity_spawner is not None:
+        launch_config.append(
+            RegisterEventHandler(
+                OnProcessExit(
+                    target_action=joint_state_spawner,
+                    on_exit=[arm_velocity_spawner],
+                )
+            )
+        )
 
     ekf_config = os.path.join(share_folder, 'config', 'ekf.yaml')
     launch_config.append(

--- a/reseq_ros2/launch/digital_twin_launch.py
+++ b/reseq_ros2/launch/digital_twin_launch.py
@@ -78,7 +78,15 @@ def launch_setup(context, *args, **kwargs):
         LaunchConfiguration('launch_yaw_controllers').perform(context).lower() == 'true'
     )
     arm_max_cartesian_vel = float(LaunchConfiguration('arm_max_cartesian_vel').perform(context))
+    arm_max_angular_vel = float(LaunchConfiguration('arm_max_angular_vel').perform(context))
     arm_max_joint_vel = float(LaunchConfiguration('arm_max_joint_vel').perform(context))
+    arm_robot_forward_rpy = [
+        float(v)
+        for v in LaunchConfiguration('arm_robot_forward_rpy')
+        .perform(context)
+        .replace(',', ' ')
+        .split()
+    ]
 
     arm_arg = LaunchConfiguration('arm').perform(context=context)
     arm = arm_arg == 'true'
@@ -156,8 +164,10 @@ def launch_setup(context, *args, **kwargs):
         for i in range(num_modules - 1):
             body_spawners.append(_spawner(f'yaw_controller{i + 2}', external_log_level))
 
+    arm_velocity_spawner = None
     if arm:
-        body_spawners.append(_spawner('joint_group_velocity_controller', external_log_level))
+        arm_velocity_spawner = _spawner('joint_group_velocity_controller', external_log_level)
+        body_spawners.append(arm_velocity_spawner)
 
     for i in range(num_modules):
         body_spawners.append(_spawner(f'imu{i + 1}_broadcaster', external_log_level))
@@ -213,30 +223,39 @@ def launch_setup(context, *args, **kwargs):
         )
 
     if arm:
+        arm_chain_tip = 'cameras_holder_link' if sim_mode == 'true' else 'tcp'
         arm_state_topic = '/joint_states' if sim_mode == 'true' else '/arm_joint_states'
-        launch_config.append(
-            Node(
-                package='reseq_arm_mk2',
-                executable='cartesian_arm_controller.py',
-                name='cartesian_arm_controller',
-                parameters=[
-                    {
-                        'robot_description': robot_description,
-                        'use_sim_time': sim_branch_use_sim_time == 'true',
-                        'state_topic': arm_state_topic,
-                        'velocity_topic': '/mk2_arm_vel_scaled',
-                        'chain_tip': 'tcp',
-                        'command_frame': 'arm_base_link',
-                        'command_mode': 'velocity',
-                        'max_cartesian_vel': arm_max_cartesian_vel,
-                        'max_joint_vel': arm_max_joint_vel,
-                        'deadzone': 0.02,
-                        'trajectory_horizon_sec': 0.1,
-                    }
-                ],
-                output='screen',
-            )
+        cartesian_arm_node = Node(
+            package='reseq_arm_mk2',
+            executable='cartesian_arm_controller.py',
+            name='cartesian_arm_controller',
+            parameters=[
+                {
+                    'robot_description': robot_description,
+                    'use_sim_time': sim_branch_use_sim_time == 'true',
+                    'state_topic': arm_state_topic,
+                    'velocity_topic': '/mk2_arm_vel_scaled',
+                    'chain_tip': arm_chain_tip,
+                    'command_frame': 'arm_base_link',
+                    'command_mode': 'velocity',
+                    'max_cartesian_vel': arm_max_cartesian_vel,
+                    'max_angular_vel': arm_max_angular_vel,
+                    'max_joint_vel': arm_max_joint_vel,
+                    'robot_forward_rpy': arm_robot_forward_rpy,
+                    'deadzone': 0.02,
+                    'trajectory_horizon_sec': 0.1,
+                }
+            ],
+            output='screen',
         )
+        if arm_velocity_spawner is not None:
+            launch_config.append(
+                RegisterEventHandler(
+                    OnProcessExit(target_action=arm_velocity_spawner, on_exit=[cartesian_arm_node])
+                )
+            )
+        else:
+            launch_config.append(cartesian_arm_node)
 
     if sim_mode == 'false' and arm and use_moveit:
         launch_config.append(
@@ -282,9 +301,19 @@ def generate_launch_description():
                 description='Cartesian velocity scale for the arm controller',
             ),
             DeclareLaunchArgument(
+                'arm_max_angular_vel',
+                default_value='0.8',
+                description='Angular velocity scale for arm rotation mode',
+            ),
+            DeclareLaunchArgument(
                 'arm_max_joint_vel',
                 default_value='0.8',
                 description='Joint velocity clamp for the arm controller',
+            ),
+            DeclareLaunchArgument(
+                'arm_robot_forward_rpy',
+                default_value='0.0 0.0 0.0',
+                description='Fixed robot-forward tool orientation RPY relative to arm_base_link',
             ),
             DeclareLaunchArgument(
                 'use_moveit',

--- a/reseq_ros2/launch/reseq_launch.py
+++ b/reseq_ros2/launch/reseq_launch.py
@@ -44,7 +44,9 @@ def launch_setup(context, *args, **kwargs):
     use_moveit = LaunchConfiguration('use_moveit').perform(context)
     launch_yaw_controllers = LaunchConfiguration('launch_yaw_controllers').perform(context)
     arm_max_cartesian_vel = LaunchConfiguration('arm_max_cartesian_vel').perform(context)
+    arm_max_angular_vel = LaunchConfiguration('arm_max_angular_vel').perform(context)
     arm_max_joint_vel = LaunchConfiguration('arm_max_joint_vel').perform(context)
+    arm_robot_forward_rpy = LaunchConfiguration('arm_robot_forward_rpy').perform(context)
     arm_arg = LaunchConfiguration('arm').perform(context=context)
     arm = True if arm_arg == 'true' else False
 
@@ -158,7 +160,9 @@ def launch_setup(context, *args, **kwargs):
                 'use_sim_time': use_sim_time,
                 'sim_mode': sim_mode,
                 'arm_max_cartesian_vel': arm_max_cartesian_vel,
+                'arm_max_angular_vel': arm_max_angular_vel,
                 'arm_max_joint_vel': arm_max_joint_vel,
+                'arm_robot_forward_rpy': arm_robot_forward_rpy,
                 'use_moveit': use_moveit,
                 'launch_yaw_controllers': launch_yaw_controllers,
             }.items(),
@@ -318,9 +322,19 @@ def generate_launch_description():
                 description='Cartesian velocity scale for the arm controller',
             ),
             DeclareLaunchArgument(
+                'arm_max_angular_vel',
+                default_value='0.8',
+                description='Angular velocity scale for arm rotation mode',
+            ),
+            DeclareLaunchArgument(
                 'arm_max_joint_vel',
                 default_value='0.8',
                 description='Joint velocity clamp for the arm controller',
+            ),
+            DeclareLaunchArgument(
+                'arm_robot_forward_rpy',
+                default_value='0.0 0.0 0.0',
+                description='Fixed robot-forward tool orientation RPY relative to arm_base_link',
             ),
             DeclareLaunchArgument('use_moveit', default_value='false'),
             DeclareLaunchArgument('launch_yaw_controllers', default_value='false'),

--- a/reseq_ros2/launch/reseq_launch.py
+++ b/reseq_ros2/launch/reseq_launch.py
@@ -318,17 +318,17 @@ def generate_launch_description():
             DeclareLaunchArgument('sim_mode', default_value='false'),
             DeclareLaunchArgument(
                 'arm_max_cartesian_vel',
-                default_value='0.4',
+                default_value='0.8',
                 description='Cartesian velocity scale for the arm controller',
             ),
             DeclareLaunchArgument(
                 'arm_max_angular_vel',
-                default_value='0.8',
+                default_value='2.4',
                 description='Angular velocity scale for arm rotation mode',
             ),
             DeclareLaunchArgument(
                 'arm_max_joint_vel',
-                default_value='0.8',
+                default_value='1.6',
                 description='Joint velocity clamp for the arm controller',
             ),
             DeclareLaunchArgument(

--- a/reseq_ros2/reseq_ros2/scaler.py
+++ b/reseq_ros2/reseq_ros2/scaler.py
@@ -57,6 +57,14 @@ class Scaler(Node):
             'condition': lambda b: not b[Scaler.buttons_enum.BBLUE],
         },
         {
+            'name': 'Switch MK2 Arm End-Effector Mode',
+            'button': buttons_enum.S4,
+            'service': '/cartesian_arm_controller/switch_vel',
+            # Switches read False in the upper position. The arm controller
+            # expects True=linear, False=rotation.
+            'inverted': True,
+        },
+        {
             'name': 'Switch type of velocity of mk2 arm',
             'button': buttons_enum.BGREEN,
             'service': '/moveit_controller/switch_vel',


### PR DESCRIPTION
This PR adds end-effector based control for the MK2 arm and wires it into the ROS 2 launch/scaler flow.

Changes include:

- Added a Cartesian arm controller mode that supports linear end-effector translation and rotation-oriented control.
- Added mode switching so linear mode keeps the tool/camera steady and forward-facing while translating.
- Added joint velocity solving with limit clipping and redistribution to keep commands bounded.
- Integrated the arm mode control path into the scaler node.
- Updated launch files so the Cartesian arm controller is started with the relevant configuration in digital twin and standard launch flows.
- Added logging for commanded Cartesian input, joint commands, measured state, clipping, and end-effector position to help with tuning and debugging.